### PR TITLE
Feature/external proxy

### DIFF
--- a/frontend/src/SettingsManager/ExternalProxyInput/index.tsx
+++ b/frontend/src/SettingsManager/ExternalProxyInput/index.tsx
@@ -35,16 +35,21 @@ export function ExternalProxyInput() {
 
     useEffect(() => {
         (async () => {
-            const config = await GetExternalProxy();
-            setState({
-                enabled: config?.enabled ?? false,
-                protocol: config?.protocol ?? 'socks5',
-                host: config?.host ?? '',
-                port: config?.port ?? 0,
-                username: config?.username ?? '',
-                password: config?.password ?? '',
-                loading: false,
-            });
+            try {
+                const config = await GetExternalProxy();
+                setState({
+                    enabled: config?.enabled ?? false,
+                    protocol: config?.protocol ?? 'socks5',
+                    host: config?.host ?? '',
+                    port: config?.port ?? 0,
+                    username: config?.username ?? '',
+                    password: config?.password ?? '',
+                    loading: false,
+                });
+            } catch (ex) {
+                console.error('Failed to load external proxy config:', ex);
+                setState((prev) => ({ ...prev, loading: false }));
+            }
         })();
     }, []);
 
@@ -53,7 +58,9 @@ export function ExternalProxyInput() {
             await SetExternalProxy(config);
         } catch (ex) {
             AppToaster.show({
-                message: t('externalProxy.saveError', { error: ex }),
+                message: t('externalProxy.saveError', {
+                    error: ex instanceof Error ? ex.message : String(ex),
+                }),
                 intent: 'danger',
             });
         }
@@ -62,14 +69,18 @@ export function ExternalProxyInput() {
     const update = (patch: Partial<ExternalProxyConfig>) => {
         setState((prev) => {
             const updated = { ...prev, ...patch };
-            saveConfig({
+            const config: ExternalProxyConfig = {
                 enabled: updated.enabled,
                 protocol: updated.protocol,
                 host: updated.host,
                 port: updated.port,
                 username: updated.username,
                 password: updated.password,
-            });
+            };
+            // Only persist when disabled OR when enabled with valid host+port
+            if (!config.enabled || (config.host.trim() !== '' && config.port >= 1 && config.port <= 65535)) {
+                saveConfig(config);
+            }
             return updated;
         });
     };

--- a/frontend/src/SettingsManager/ExternalProxyInput/index.tsx
+++ b/frontend/src/SettingsManager/ExternalProxyInput/index.tsx
@@ -1,0 +1,161 @@
+import { FormGroup, HTMLSelect, InputGroup, NumericInput, Switch, Tooltip } from '@blueprintjs/core';
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useDebouncedCallback } from 'use-debounce';
+
+import { GetExternalProxy, SetExternalProxy } from '../../../wailsjs/go/cfg/Config';
+import { AppToaster } from '../../common/toaster';
+import { useProxyState } from '../../context/ProxyStateContext';
+
+interface ExternalProxyConfig {
+    enabled: boolean;
+    protocol: string;
+    host: string;
+    port: number;
+    username: string;
+    password: string;
+}
+
+const defaultConfig: ExternalProxyConfig = {
+    enabled: false,
+    protocol: 'socks5',
+    host: '',
+    port: 0,
+    username: '',
+    password: '',
+};
+
+export function ExternalProxyInput() {
+    const { t } = useTranslation();
+    const { isProxyRunning } = useProxyState();
+    const [state, setState] = useState<ExternalProxyConfig & { loading: boolean }>({
+        ...defaultConfig,
+        loading: true,
+    });
+
+    useEffect(() => {
+        (async () => {
+            const config = await GetExternalProxy();
+            setState({
+                enabled: config?.enabled ?? false,
+                protocol: config?.protocol ?? 'socks5',
+                host: config?.host ?? '',
+                port: config?.port ?? 0,
+                username: config?.username ?? '',
+                password: config?.password ?? '',
+                loading: false,
+            });
+        })();
+    }, []);
+
+    const saveConfig = useDebouncedCallback(async (config: ExternalProxyConfig) => {
+        try {
+            await SetExternalProxy(config);
+        } catch (ex) {
+            AppToaster.show({
+                message: t('externalProxy.saveError', { error: ex }),
+                intent: 'danger',
+            });
+        }
+    }, 500);
+
+    const update = (patch: Partial<ExternalProxyConfig>) => {
+        setState((prev) => {
+            const updated = { ...prev, ...patch };
+            saveConfig({
+                enabled: updated.enabled,
+                protocol: updated.protocol,
+                host: updated.host,
+                port: updated.port,
+                username: updated.username,
+                password: updated.password,
+            });
+            return updated;
+        });
+    };
+
+    return (
+        <FormGroup
+            label={t('externalProxy.label')}
+            helperText={t('externalProxy.description')}
+        >
+            <Tooltip
+                content={t('common.stopProxyToModify') as string}
+                disabled={!isProxyRunning}
+                placement="top"
+            >
+                <Switch
+                    id="externalProxy"
+                    checked={state.enabled}
+                    label={t('externalProxy.enabled') as string}
+                    size="large"
+                    disabled={state.loading || isProxyRunning}
+                    onClick={() => update({ enabled: !state.enabled })}
+                />
+            </Tooltip>
+
+            {state.enabled && (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '8px', marginTop: '8px' }}>
+                    <FormGroup label={t('externalProxy.protocol')} labelFor="externalProxyProtocol" inline>
+                        <HTMLSelect
+                            id="externalProxyProtocol"
+                            value={state.protocol}
+                            options={[
+                                { value: 'socks5', label: 'SOCKS5' },
+                                { value: 'http', label: 'HTTP' },
+                            ]}
+                            onChange={(e) => update({ protocol: e.target.value })}
+                            disabled={state.loading || isProxyRunning}
+                        />
+                    </FormGroup>
+
+                    <FormGroup label={t('externalProxy.host')} labelFor="externalProxyHost" inline>
+                        <InputGroup
+                            id="externalProxyHost"
+                            placeholder="127.0.0.1"
+                            value={state.host}
+                            onChange={(e) => update({ host: e.target.value })}
+                            disabled={state.loading || isProxyRunning}
+                        />
+                    </FormGroup>
+
+                    <FormGroup label={t('externalProxy.port')} labelFor="externalProxyPort" inline>
+                        <NumericInput
+                            id="externalProxyPort"
+                            min={1}
+                            max={65535}
+                            value={state.port}
+                            onValueChange={(port) => {
+                                if (!Number.isNaN(port)) {
+                                    update({ port });
+                                }
+                            }}
+                            disabled={state.loading || isProxyRunning}
+                        />
+                    </FormGroup>
+
+                    <FormGroup label={t('externalProxy.username')} labelFor="externalProxyUsername" inline>
+                        <InputGroup
+                            id="externalProxyUsername"
+                            placeholder={t('externalProxy.optionalPlaceholder') as string}
+                            value={state.username}
+                            onChange={(e) => update({ username: e.target.value })}
+                            disabled={state.loading || isProxyRunning}
+                        />
+                    </FormGroup>
+
+                    <FormGroup label={t('externalProxy.password')} labelFor="externalProxyPassword" inline>
+                        <InputGroup
+                            id="externalProxyPassword"
+                            type="password"
+                            placeholder={t('externalProxy.optionalPlaceholder') as string}
+                            value={state.password}
+                            onChange={(e) => update({ password: e.target.value })}
+                            disabled={state.loading || isProxyRunning}
+                        />
+                    </FormGroup>
+                </div>
+            )}
+        </FormGroup>
+    );
+}

--- a/frontend/src/SettingsManager/index.tsx
+++ b/frontend/src/SettingsManager/index.tsx
@@ -15,6 +15,7 @@ import { AutostartSwitch } from './AutostartSwitch';
 import { AutoupdateSwitch } from './AutoupdateSwitch';
 import { ExportDebugDataButton } from './ExportDebugDataButton';
 import { ExportLogsButton } from './ExportLogsButton';
+import { ExternalProxyInput } from './ExternalProxyInput';
 import { IgnoredHostsInput } from './IgnoredHostsInput';
 import { LocaleSelector } from './LocaleSelector';
 import { PortInput } from './PortInput';
@@ -73,6 +74,7 @@ export function SettingsManager() {
           <PortInput />
           <AssetPortInput />
           <IgnoredHostsInput />
+          <ExternalProxyInput />
           <UninstallCADialog proxyState={proxyState} />
         </div>
       </div>

--- a/frontend/src/i18n/locales/en-US.json
+++ b/frontend/src/i18n/locales/en-US.json
@@ -72,6 +72,18 @@
     "success": "Debug data copied to clipboard",
     "error": "Failed to export debug data: {{error}}"
   },
+  "externalProxy": {
+    "label": "External proxy",
+    "description": "Route unblocked traffic through an external HTTP or SOCKS5 proxy.",
+    "enabled": "Enabled",
+    "protocol": "Protocol",
+    "host": "Host",
+    "port": "Port",
+    "username": "Username",
+    "password": "Password",
+    "optionalPlaceholder": "Optional",
+    "saveError": "Failed to save external proxy settings: {{error}}"
+  },
   "filterLists": {
     "delete": "Delete",
     "more": "More",

--- a/frontend/wailsjs/go/cfg/Config.d.ts
+++ b/frontend/wailsjs/go/cfg/Config.d.ts
@@ -13,6 +13,8 @@ export function GetAssetPort():Promise<number>;
 
 export function GetCAInstalled():Promise<boolean>;
 
+export function GetExternalProxy():Promise<cfg.ExternalProxyConfig>;
+
 export function GetFilterLists():Promise<Array<cfg.FilterList>>;
 
 export function GetFilterListsByLocales(arg1:Array<string>):Promise<Array<cfg.FilterList>>;
@@ -52,6 +54,8 @@ export function Save():Promise<void>;
 export function SetAssetPort(arg1:number):Promise<void>;
 
 export function SetCAInstalled(arg1:boolean):Promise<void>;
+
+export function SetExternalProxy(arg1:cfg.ExternalProxyConfig):Promise<void>;
 
 export function SetIgnoredHosts(arg1:Array<string>):Promise<void>;
 

--- a/frontend/wailsjs/go/cfg/Config.js
+++ b/frontend/wailsjs/go/cfg/Config.js
@@ -22,6 +22,10 @@ export function GetCAInstalled() {
   return window['go']['cfg']['Config']['GetCAInstalled']();
 }
 
+export function GetExternalProxy() {
+  return window['go']['cfg']['Config']['GetExternalProxy']();
+}
+
 export function GetFilterLists() {
   return window['go']['cfg']['Config']['GetFilterLists']();
 }
@@ -100,6 +104,10 @@ export function SetAssetPort(arg1) {
 
 export function SetCAInstalled(arg1) {
   return window['go']['cfg']['Config']['SetCAInstalled'](arg1);
+}
+
+export function SetExternalProxy(arg1) {
+  return window['go']['cfg']['Config']['SetExternalProxy'](arg1);
 }
 
 export function SetIgnoredHosts(arg1) {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -5,6 +5,28 @@ export namespace cfg {
 	    PROMPT = "prompt",
 	    DISABLED = "disabled",
 	}
+	export class ExternalProxyConfig {
+	    enabled: boolean;
+	    protocol: string;
+	    host: string;
+	    port: number;
+	    username?: string;
+	    password?: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new ExternalProxyConfig(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.enabled = source["enabled"];
+	        this.protocol = source["protocol"];
+	        this.host = source["host"];
+	        this.port = source["port"];
+	        this.username = source["username"];
+	        this.password = source["password"];
+	    }
+	}
 	export class FilterList {
 	    name: string;
 	    type: string;

--- a/frontend/wailsjs/runtime/runtime.js
+++ b/frontend/wailsjs/runtime/runtime.js
@@ -48,6 +48,10 @@ export function EventsOff(eventName, ...additionalEventNames) {
     return window.runtime.EventsOff(eventName, ...additionalEventNames);
 }
 
+export function EventsOffAll() {
+  return window.runtime.EventsOffAll();
+}
+
 export function EventsOnce(eventName, callback) {
     return EventsOnMultiple(eventName, callback, 1);
 }

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/ZenPrivacy/zen-core v1.4.0
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/wailsapp/wails/v2 v2.10.2
+	github.com/wailsapp/wails/v2 v2.11.0
 	golang.org/x/sys v0.38.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 )
@@ -55,7 +55,7 @@ require (
 	github.com/tkrajina/go-reflector v0.5.8 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
-	github.com/wailsapp/go-webview2 v1.0.19 // indirect
+	github.com/wailsapp/go-webview2 v1.0.22 // indirect
 	github.com/wailsapp/mimetype v1.4.1 // indirect
 	go.opentelemetry.io/otel v1.14.0 // indirect
 	go.opentelemetry.io/otel/trace v1.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -123,12 +123,12 @@ github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6Kllzaw
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQD0Loo=
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
-github.com/wailsapp/go-webview2 v1.0.19 h1:7U3QcDj1PrBPaxJNCui2k1SkWml+Q5kvFUFyTImA6NU=
-github.com/wailsapp/go-webview2 v1.0.19/go.mod h1:qJmWAmAmaniuKGZPWwne+uor3AHMB5PFhqiK0Bbj8kc=
+github.com/wailsapp/go-webview2 v1.0.22 h1:YT61F5lj+GGaat5OB96Aa3b4QA+mybD0Ggq6NZijQ58=
+github.com/wailsapp/go-webview2 v1.0.22/go.mod h1:qJmWAmAmaniuKGZPWwne+uor3AHMB5PFhqiK0Bbj8kc=
 github.com/wailsapp/mimetype v1.4.1 h1:pQN9ycO7uo4vsUUuPeHEYoUkLVkaRntMnHJxVwYhwHs=
 github.com/wailsapp/mimetype v1.4.1/go.mod h1:9aV5k31bBOv5z6u+QP8TltzvNGJPmNJD4XlAL3U+j3o=
-github.com/wailsapp/wails/v2 v2.10.2 h1:29U+c5PI4K4hbx8yFbFvwpCuvqK9VgNv8WGobIlKlXk=
-github.com/wailsapp/wails/v2 v2.10.2/go.mod h1:XuN4IUOPpzBrHUkEd7sCU5ln4T/p1wQedfxP7fKik+4=
+github.com/wailsapp/wails/v2 v2.11.0 h1:seLacV8pqupq32IjS4Y7V8ucab0WZwtK6VvUVxSBtqQ=
+github.com/wailsapp/wails/v2 v2.11.0/go.mod h1:jrf0ZaM6+GBc1wRmXsM8cIvzlg0karYin3erahI4+0k=
 github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
 github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -216,7 +216,17 @@ func (a *App) StartProxy() (err error) {
 	}
 	a.whitelistSrv = whitelistSrv
 
-	a.proxy, err = proxy.NewProxy(filter, certGenerator, a.config.GetPort())
+	var proxyOpts []proxy.ProxyOption
+	if epc := a.config.GetExternalProxy(); epc != nil && epc.Enabled {
+		proxyOpts = append(proxyOpts, proxy.WithExternalProxy(proxy.ExternalProxyConfig{
+			Protocol: epc.Protocol,
+			Host:     epc.Host,
+			Port:     epc.Port,
+			Username: epc.Username,
+			Password: epc.Password,
+		}))
+	}
+	a.proxy, err = proxy.NewProxy(filter, certGenerator, a.config.GetPort(), proxyOpts...)
 	if err != nil {
 		return fmt.Errorf("create proxy: %v", err)
 	}

--- a/internal/cfg/config.go
+++ b/internal/cfg/config.go
@@ -464,19 +464,43 @@ func (c *Config) SetAssetPort(port int) error {
 }
 
 // GetExternalProxy returns the external proxy configuration.
+// Returns a defensive copy so callers cannot mutate internal state.
 func (c *Config) GetExternalProxy() *ExternalProxyConfig {
 	c.RLock()
 	defer c.RUnlock()
 
-	return c.Proxy.ExternalProxy
+	if c.Proxy.ExternalProxy == nil {
+		return nil
+	}
+	copy := *c.Proxy.ExternalProxy
+	return &copy
 }
 
 // SetExternalProxy sets the external proxy configuration.
+// Validates connection settings when the proxy is enabled.
 func (c *Config) SetExternalProxy(epc *ExternalProxyConfig) error {
+	if epc != nil && epc.Enabled {
+		if epc.Protocol != "http" && epc.Protocol != "socks5" {
+			return fmt.Errorf("protocol must be \"http\" or \"socks5\"")
+		}
+		if epc.Host == "" {
+			return fmt.Errorf("host must not be empty")
+		}
+		if epc.Port < 1 || epc.Port > 65535 {
+			return fmt.Errorf("port must be between 1 and 65535")
+		}
+	}
+
 	c.Lock()
 	defer c.Unlock()
 
-	c.Proxy.ExternalProxy = epc
+	// Store a defensive copy to avoid shared mutable state.
+	if epc != nil {
+		copy := *epc
+		c.Proxy.ExternalProxy = &copy
+	} else {
+		c.Proxy.ExternalProxy = nil
+	}
 	if err := c.Save(); err != nil {
 		log.Printf("failed to save config: %v", err)
 		return err

--- a/internal/cfg/config.go
+++ b/internal/cfg/config.go
@@ -64,6 +64,16 @@ type FilterList struct {
 	Locales []string       `json:"locales"`
 }
 
+// ExternalProxyConfig holds the configuration for an external upstream proxy.
+type ExternalProxyConfig struct {
+	Enabled  bool   `json:"enabled"`
+	Protocol string `json:"protocol"` // "http" or "socks5"
+	Host     string `json:"host"`
+	Port     int    `json:"port"`
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
+}
+
 // Config stores and manages the configuration for the application.
 // Although all fields are public, this is only for use by the JSON marshaller.
 // All access to the Config should be done through the exported methods.
@@ -81,9 +91,10 @@ type Config struct {
 		CAInstalled bool `json:"caInstalled"`
 	} `json:"certmanager"`
 	Proxy struct {
-		Port         int      `json:"port"`
-		IgnoredHosts []string `json:"ignoredHosts"`
-		PACPort      int      `json:"pacPort"`
+		Port          int                  `json:"port"`
+		IgnoredHosts  []string             `json:"ignoredHosts"`
+		PACPort       int                  `json:"pacPort"`
+		ExternalProxy *ExternalProxyConfig `json:"externalProxy,omitempty"`
 	} `json:"proxy"`
 	UpdatePolicy UpdatePolicyType `json:"updatePolicy"`
 
@@ -445,6 +456,27 @@ func (c *Config) SetAssetPort(port int) error {
 	defer c.Unlock()
 
 	c.Filter.AssetPort = port
+	if err := c.Save(); err != nil {
+		log.Printf("failed to save config: %v", err)
+		return err
+	}
+	return nil
+}
+
+// GetExternalProxy returns the external proxy configuration.
+func (c *Config) GetExternalProxy() *ExternalProxyConfig {
+	c.RLock()
+	defer c.RUnlock()
+
+	return c.Proxy.ExternalProxy
+}
+
+// SetExternalProxy sets the external proxy configuration.
+func (c *Config) SetExternalProxy(epc *ExternalProxyConfig) error {
+	c.Lock()
+	defer c.Unlock()
+
+	c.Proxy.ExternalProxy = epc
 	if err := c.Save(); err != nil {
 		log.Printf("failed to save config: %v", err)
 		return err


### PR DESCRIPTION
What does this PR do?
This PR adds support for routing Zen's unblocked traffic through an external HTTP or SOCKS5 proxy, enabling Zen to work alongside VPNs, corporate proxies, and tools like Tor.

Architecture:
Client → Zen (filter/block) → External Proxy → Internet
Changes:

Backend (internal/):
cfg/config.go
 — Added 

ExternalProxyConfig
 struct with protocol, host, port, and optional username/password fields. Added 

GetExternalProxy()
/

SetExternalProxy()
 methods following existing getter/setter patterns.

app/app.go
 — 

StartProxy()
 now reads the external proxy config and passes proxy.WithExternalProxy() option to proxy.NewProxy().
Frontend (frontend/src/):

New SettingsManager/ExternalProxyInput/ component — enable toggle, protocol dropdown (HTTP/SOCKS5), host, port, username, and password fields. Follows existing patterns (useState, useEffect, useDebouncedCallback, disabled when proxy is running).
Added to the Advanced section in 

SettingsManager/index.tsx
.
Added externalProxy.* i18n keys to 

en-US.json
.
Note: This PR requires corresponding changes to zen-core — adding a proxy.Dialer interface field, 

WithExternalProxy()
 functional option, and 

httpConnectDialer
 for HTTP CONNECT proxies. SOCKS5 support uses the existing golang.org/x/net/proxy dependency.

How did you verify your code works?
Go backend builds cleanly (go build ./...)
Frontend compiles with no TypeScript errors
App launches in dev mode and the External Proxy settings render correctly in Settings → Advanced
Unit tests for 

httpConnectDialer
 pass: tested HTTP CONNECT tunneling, Basic auth (rejection + success), and 

WithExternalProxy()
 option application
Regression: verified the app starts and functions normally with no external proxy configured
What are the relevant issues?
Closes #609


