### PR TITLE
Update create-dmg to 8.1.0

### DIFF
--- a/tasks/build/Taskfile-darwin.yml
+++ b/tasks/build/Taskfile-darwin.yml
@@ -42,7 +42,7 @@ tasks:
   deps:
     desc: Install the dependencies required to create a production build.
     cmds:
-      - npm i -g create-dmg@^7.0.0
+      - npm i -g create-dmg@8.1.0
 
   app:
     desc: Build the .app application bundle. The .app file will be placed in the build/bin directory.
@@ -57,7 +57,7 @@ tasks:
   dmg:
     desc: Create a DMG installer for the application. The DMG file will be placed in the build/bin directory.
     cmds:
-      - create-dmg "{{default .DEFAULT_APP_FILENAME .APP_FILENAME}}" --overwrite
+      - create-dmg "{{default .DEFAULT_APP_FILENAME .APP_FILENAME}}" --overwrite --no-code-sign
       - mv Zen*.dmg build/bin/Zen.dmg # create-dmg creates the disk image in the current directory
       - echo "Built Zen.dmg"
     vars:


### PR DESCRIPTION
### What does this PR do?

Self-explanatory, mostly done for the updated icon introduced in https://github.com/sindresorhus/create-dmg/pull/102. Also pins the version for added security.

See `create-dmg`'s changelog for more details: https://github.com/sindresorhus/create-dmg/releases.

### How did you verify your code works?

CI runs.

### What are the relevant issues?

<!--
**Please link any relevant issues**, for example:

Closes #123
-->
