### PR TITLE
internal/config: remove stale anti-adblock list

### DIFF
--- a/internal/config/default-config.json
+++ b/internal/config/default-config.json
@@ -312,13 +312,6 @@
         "locales": ["pl"]
       },
       {
-        "url": "https://raw.githubusercontent.com/olegwukr/polish-privacy-filters/master/anti-adblock.txt",
-        "name": "🇵🇱PL: Oficjalne polskie filtry przeciwko alertom o Adblocku",
-        "enabled": false,
-        "type": "regional",
-        "locales": ["pl"]
-      },
-      {
         "url": "https://raw.githubusercontent.com/tcptomato/ROad-Block/master/road-block-filters-light.txt",
         "name": "🇷🇴RO 🇲🇩MD: Romanian Ad (ROad) Block List Light",
         "enabled": false,

--- a/internal/config/migrations.go
+++ b/internal/config/migrations.go
@@ -336,6 +336,26 @@ var migrations = []migration{
 			return nil
 		})
 	}},
+	{"v0.22.0", func(c *Config) error {
+		const removedURL = "https://raw.githubusercontent.com/olegwukr/polish-privacy-filters/master/anti-adblock.txt"
+
+		return c.update(func() error {
+			filtered := c.Filter.FilterLists[:0]
+			removed := false
+			for _, fl := range c.Filter.FilterLists {
+				if fl.URL == removedURL {
+					removed = true
+					continue
+				}
+				filtered = append(filtered, fl)
+			}
+			c.Filter.FilterLists = filtered
+			if removed {
+				log.Printf("v0.22.0 migration: removed stale anti-adblock list")
+			}
+			return nil
+		})
+	}},
 }
 
 // RunMigrations runs the version-to-version migrations in order.

--- a/internal/config/migrations_test.go
+++ b/internal/config/migrations_test.go
@@ -1,0 +1,43 @@
+package config
+
+import "testing"
+
+func TestMigrationV0220RemovesStaleAntiAdblockList(t *testing.T) {
+	prevConfigDir := ConfigDir
+	ConfigDir = t.TempDir()
+	t.Cleanup(func() {
+		ConfigDir = prevConfigDir
+	})
+
+	const removedURL = "https://raw.githubusercontent.com/olegwukr/polish-privacy-filters/master/anti-adblock.txt"
+	const keepURL = "https://example.com/keep.txt"
+
+	c := &Config{}
+	c.Filter.FilterLists = []FilterList{
+		{URL: keepURL},
+		{URL: removedURL},
+		{URL: removedURL},
+	}
+
+	var m *migration
+	for i := range migrations {
+		if migrations[i].version == "v0.22.0" {
+			m = &migrations[i]
+			break
+		}
+	}
+	if m == nil {
+		t.Fatal("v0.22.0 migration not found")
+	}
+
+	if err := m.fn(c); err != nil {
+		t.Fatalf("run migration: %v", err)
+	}
+
+	if len(c.Filter.FilterLists) != 1 {
+		t.Fatalf("expected 1 list after migration, got %d", len(c.Filter.FilterLists))
+	}
+	if c.Filter.FilterLists[0].URL != keepURL {
+		t.Fatalf("unexpected list URL after migration: %s", c.Filter.FilterLists[0].URL)
+	}
+}


### PR DESCRIPTION
﻿Removed the stale anti-adblock list from the default config and added a migration so existing installs drop the old data on upgrade.

I also added a migration test in `internal/config/migrations_test.go`.

closes #477
