### PR TITLE
Implement support for regexp rules

### DIFF
--- a/internal/networkrules/networkrules.go
+++ b/internal/networkrules/networkrules.go
@@ -7,10 +7,9 @@ import (
 
 	"github.com/irbis-sh/zen-desktop/internal/networkrules/exceptionrule"
 	"github.com/irbis-sh/zen-desktop/internal/networkrules/rule"
-	"github.com/irbis-sh/zen-desktop/internal/ruletree"
 )
 
-type ruleStore[T any] interface {
+type ruleStore[T comparable] interface {
 	Insert(string, T)
 	Get(string) []T
 	Compact()
@@ -23,8 +22,8 @@ type NetworkRules struct {
 
 func New() *NetworkRules {
 	return &NetworkRules{
-		primaryStore:   ruletree.New[*rule.Rule](),
-		exceptionStore: ruletree.New[*exceptionrule.ExceptionRule](),
+		primaryStore:   newRuleStore[*rule.Rule](),
+		exceptionStore: newRuleStore[*exceptionrule.ExceptionRule](),
 	}
 }
 

--- a/internal/networkrules/networkrules.go
+++ b/internal/networkrules/networkrules.go
@@ -9,15 +9,9 @@ import (
 	"github.com/irbis-sh/zen-desktop/internal/networkrules/rule"
 )
 
-type ruleStore[T comparable] interface {
-	Insert(string, T)
-	Get(string) []T
-	Compact()
-}
-
 type NetworkRules struct {
-	primaryStore   ruleStore[*rule.Rule]
-	exceptionStore ruleStore[*exceptionrule.ExceptionRule]
+	primaryStore   *ruleStore[*rule.Rule]
+	exceptionStore *ruleStore[*exceptionrule.ExceptionRule]
 }
 
 func New() *NetworkRules {

--- a/internal/networkrules/networkrules.go
+++ b/internal/networkrules/networkrules.go
@@ -4,17 +4,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"regexp"
-	"strings"
 
 	"github.com/irbis-sh/zen-desktop/internal/networkrules/exceptionrule"
 	"github.com/irbis-sh/zen-desktop/internal/networkrules/rule"
 	"github.com/irbis-sh/zen-desktop/internal/ruletree"
-)
-
-var (
-	reHosts       = regexp.MustCompile(`^(?:0\.0\.0\.0|127\.0\.0\.1)\s(.+)`)
-	reHostsIgnore = regexp.MustCompile(`^(?:0\.0\.0\.0|broadcasthost|local|localhost(?:\.localdomain)?|ip6-\w+)$`)
 )
 
 type ruleStore[T any] interface {
@@ -33,80 +26,6 @@ func New() *NetworkRules {
 		primaryStore:   ruletree.New[*rule.Rule](),
 		exceptionStore: ruletree.New[*exceptionrule.ExceptionRule](),
 	}
-}
-
-func (nr *NetworkRules) ParseRule(rawRule string, filterName *string) (isException bool, err error) {
-	if matches := reHosts.FindStringSubmatch(rawRule); matches != nil {
-		hostsField := matches[1]
-		if commentIndex := strings.IndexByte(hostsField, '#'); commentIndex != -1 {
-			hostsField = hostsField[:commentIndex]
-		}
-
-		// An IP address may be followed by multiple hostnames.
-		//
-		// As stated in https://man.freebsd.org/cgi/man.cgi?hosts(5):
-		// "Items are separated by any number of blanks and/or tab characters."
-		hosts := strings.Fields(hostsField)
-
-		for _, host := range hosts {
-			if reHostsIgnore.MatchString(host) {
-				continue
-			}
-
-			pattern := fmt.Sprintf("||%s^", host)
-			nr.primaryStore.Insert(pattern, &rule.Rule{
-				RawRule:    rawRule,
-				FilterName: filterName,
-				Document:   true,
-			})
-		}
-
-		return false, nil
-	}
-
-	if strings.HasPrefix(rawRule, "@@") {
-		r := &exceptionrule.ExceptionRule{
-			RawRule:    rawRule,
-			FilterName: filterName,
-		}
-
-		pattern, modifiers, found := strings.Cut(rawRule[2:], "$")
-		if pattern != "" && pattern[0] == '/' && pattern[len(pattern)-1] == '/' {
-			// This is a regexp rule.
-			// TODO: implement proper support for regexp rules.
-			return true, nil
-		}
-		if found {
-			modifiersArr := splitModifiers(modifiers)
-			if err := r.ParseModifiers(modifiersArr); err != nil {
-				return false, fmt.Errorf("parse modifiers: %v", err)
-			}
-		}
-		nr.exceptionStore.Insert(pattern, r)
-
-		return true, nil
-	}
-
-	r := &rule.Rule{
-		RawRule:    rawRule,
-		FilterName: filterName,
-	}
-
-	pattern, modifiers, found := strings.Cut(rawRule, "$")
-	if pattern != "" && pattern[0] == '/' && pattern[len(pattern)-1] == '/' {
-		// This is a regexp rule.
-		// TODO: implement proper support for regexp rules.
-		return false, nil
-	}
-	if found {
-		modifiersArr := splitModifiers(modifiers)
-		if err := r.ParseModifiers(modifiersArr); err != nil {
-			return false, fmt.Errorf("parse modifiers: %v", err)
-		}
-	}
-	nr.primaryStore.Insert(pattern, r)
-
-	return false, nil
 }
 
 func (nr *NetworkRules) ModifyReq(req *http.Request) (appliedRules []rule.Rule, shouldBlock bool, redirectURL string) {
@@ -234,42 +153,4 @@ func renderURLWithoutPort(u *url.URL) string {
 	}
 
 	return stripped.String()
-}
-
-// splitModifiers splits by unescaped commas.
-// Empty fields are preserved (like strings.Split).
-func splitModifiers(s string) []string {
-	var res []string
-	var b strings.Builder
-	escaped := false
-
-	for _, r := range s {
-		switch r {
-		case '\\':
-			if escaped {
-				b.WriteRune('\\')
-			}
-			escaped = !escaped
-		case ',':
-			if escaped {
-				b.WriteRune(',')
-				escaped = false
-			} else {
-				res = append(res, b.String())
-				b.Reset()
-			}
-		default:
-			if escaped {
-				b.WriteRune('\\')
-				escaped = false
-			}
-			b.WriteRune(r)
-		}
-	}
-
-	if escaped {
-		b.WriteRune('\\')
-	}
-	res = append(res, b.String())
-	return res
 }

--- a/internal/networkrules/networkrules_test.go
+++ b/internal/networkrules/networkrules_test.go
@@ -1,0 +1,188 @@
+package networkrules
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func TestRegexpRules(t *testing.T) {
+	t.Parallel()
+
+	t.Run("blocks matching request", func(t *testing.T) {
+		t.Parallel()
+
+		nr := New()
+		if _, err := nr.ParseRule(`/ads\d+\.js/`, nil); err != nil {
+			t.Fatal(err)
+		}
+
+		_, shouldBlock, _ := nr.ModifyReq(newTestRequest(t, "https://example.com/ads123.js", nil))
+		if !shouldBlock {
+			t.Fatal("expected rule to block matching request")
+		}
+	})
+
+	t.Run("does not block nonmatching request", func(t *testing.T) {
+		t.Parallel()
+
+		nr := New()
+		if _, err := nr.ParseRule(`/ads\d+\.js/`, nil); err != nil {
+			t.Fatal(err)
+		}
+
+		_, shouldBlock, _ := nr.ModifyReq(newTestRequest(t, "https://example.com/ad.js", nil))
+		if shouldBlock {
+			t.Fatal("expected rule not to block nonmatching request")
+		}
+	})
+
+	t.Run("respects request modifiers", func(t *testing.T) {
+		t.Parallel()
+
+		nr := New()
+		if _, err := nr.ParseRule(`/\/[0-9a-f]{32}\/invoke\.js/$script,third-party,domain=metbuat.az`, nil); err != nil {
+			t.Fatal(err)
+		}
+
+		headers := http.Header{
+			"Referer":        []string{"https://metbuat.az/page"},
+			"Sec-Fetch-Dest": []string{"script"},
+			"Sec-Fetch-Site": []string{"cross-site"},
+		}
+		_, shouldBlock, _ := nr.ModifyReq(newTestRequest(t, "https://cdn.example/0123456789abcdef0123456789abcdef/invoke.js", headers))
+		if !shouldBlock {
+			t.Fatal("expected rule to block when modifiers match")
+		}
+
+		headers.Set("Sec-Fetch-Dest", "image")
+		_, shouldBlock, _ = nr.ModifyReq(newTestRequest(t, "https://cdn.example/0123456789abcdef0123456789abcdef/invoke.js", headers))
+		if shouldBlock {
+			t.Fatal("expected rule not to block when content type modifier fails")
+		}
+	})
+
+	t.Run("matches unescaped slash in regexp body", func(t *testing.T) {
+		t.Parallel()
+
+		nr := New()
+		if _, err := nr.ParseRule(`/example.com/[0-9a-z]*.php/$domain=example.com`, nil); err != nil {
+			t.Fatal(err)
+		}
+
+		headers := http.Header{"Referer": []string{"https://example.com/page"}}
+		_, shouldBlock, _ := nr.ModifyReq(newTestRequest(t, "https://cdn.example/example.com/abc123.php", headers))
+		if !shouldBlock {
+			t.Fatal("expected rule with unescaped slash to block matching request")
+		}
+	})
+
+	t.Run("regexp exception cancels tree primary", func(t *testing.T) {
+		t.Parallel()
+
+		nr := New()
+		if _, err := nr.ParseRule(`||example.com/ads*`, nil); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := nr.ParseRule(`@@/ads\d+/`, nil); err != nil {
+			t.Fatal(err)
+		}
+
+		_, shouldBlock, _ := nr.ModifyReq(newTestRequest(t, "https://example.com/ads123", nil))
+		if shouldBlock {
+			t.Fatal("expected regexp exception to cancel tree primary rule")
+		}
+	})
+
+	t.Run("tree exception cancels regexp primary", func(t *testing.T) {
+		t.Parallel()
+
+		nr := New()
+		if _, err := nr.ParseRule(`/ads\d+/`, nil); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := nr.ParseRule(`@@||example.com/ads*`, nil); err != nil {
+			t.Fatal(err)
+		}
+
+		_, shouldBlock, _ := nr.ModifyReq(newTestRequest(t, "https://example.com/ads123", nil))
+		if shouldBlock {
+			t.Fatal("expected tree exception to cancel regexp primary rule")
+		}
+	})
+
+	t.Run("invalid regexp returns error", func(t *testing.T) {
+		t.Parallel()
+
+		nr := New()
+		if _, err := nr.ParseRule(`/[/$script`, nil); err == nil {
+			t.Fatal("expected invalid rule to return error")
+		}
+	})
+
+	t.Run("empty regexp returns error", func(t *testing.T) {
+		t.Parallel()
+
+		nr := New()
+		if _, err := nr.ParseRule(`//`, nil); err == nil {
+			t.Fatal("expected empty rule to return error")
+		}
+	})
+
+	t.Run("unsupported lookahead regexp returns error", func(t *testing.T) {
+		t.Parallel()
+
+		nr := New()
+		if _, err := nr.ParseRule(`/demo.example\/(?!.*animated).*\.gif/$domain=demo.example`, nil); err == nil {
+			t.Fatal("expected lookahead rule to return error")
+		}
+	})
+
+	t.Run("unsupported backreference regexp returns error", func(t *testing.T) {
+		t.Parallel()
+
+		nr := New()
+		if _, err := nr.ParseRule(`/^https:\/\/(?:loader)\.([-0-9A-Za-z]+\.[-A-Za-z]{2,16})\/(?:loader\.min|script\/(?:www\.)?\1)\.js$/$script,third-party`, nil); err == nil {
+			t.Fatal("expected backreference rule to return error")
+		}
+	})
+
+	t.Run("modifies matching response", func(t *testing.T) {
+		t.Parallel()
+
+		nr := New()
+		if _, err := nr.ParseRule(`/tracking\.js/$removeheader=X-Test`, nil); err != nil {
+			t.Fatal(err)
+		}
+
+		res := &http.Response{Header: http.Header{"X-Test": []string{"1"}}}
+		applied, err := nr.ModifyRes(newTestRequest(t, "https://example.com/tracking.js", nil), res)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(applied) != 1 {
+			t.Fatalf("applied rules = %d, want 1", len(applied))
+		}
+		if res.Header.Get("X-Test") != "" {
+			t.Fatal("expected response header to be removed")
+		}
+	})
+}
+
+func newTestRequest(t *testing.T, rawURL string, headers http.Header) *http.Request {
+	t.Helper()
+
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if headers == nil {
+		headers = http.Header{}
+	}
+
+	return &http.Request{
+		Method: http.MethodGet,
+		URL:    u,
+		Header: headers,
+	}
+}

--- a/internal/networkrules/parse.go
+++ b/internal/networkrules/parse.go
@@ -1,0 +1,135 @@
+package networkrules
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/irbis-sh/zen-desktop/internal/networkrules/exceptionrule"
+	"github.com/irbis-sh/zen-desktop/internal/networkrules/rule"
+)
+
+var (
+	reHosts       = regexp.MustCompile(`^(?:0\.0\.0\.0|127\.0\.0\.1)\s(.+)`)
+	reHostsIgnore = regexp.MustCompile(`^(?:0\.0\.0\.0|broadcasthost|local|localhost(?:\.localdomain)?|ip6-\w+)$`)
+)
+
+func (nr *NetworkRules) ParseRule(rawRule string, filterName *string) (isException bool, err error) {
+	if matches := reHosts.FindStringSubmatch(rawRule); matches != nil {
+		hostsField := matches[1]
+		if commentIndex := strings.IndexByte(hostsField, '#'); commentIndex != -1 {
+			hostsField = hostsField[:commentIndex]
+		}
+
+		// An IP address may be followed by multiple hostnames.
+		//
+		// As stated in https://man.freebsd.org/cgi/man.cgi?hosts(5):
+		// "Items are separated by any number of blanks and/or tab characters."
+		hosts := strings.Fields(hostsField)
+
+		for _, host := range hosts {
+			if reHostsIgnore.MatchString(host) {
+				continue
+			}
+
+			pattern := fmt.Sprintf("||%s^", host)
+			nr.primaryStore.Insert(pattern, &rule.Rule{
+				RawRule:    rawRule,
+				FilterName: filterName,
+				Document:   true,
+			})
+		}
+
+		return false, nil
+	}
+
+	if strings.HasPrefix(rawRule, "@@") {
+		r := &exceptionrule.ExceptionRule{
+			RawRule:    rawRule,
+			FilterName: filterName,
+		}
+
+		pattern, modifiers, isRegexp := parseRuleParts(rawRule[2:])
+		if isRegexp {
+			// This is a regexp rule.
+			// TODO: implement proper support for regexp rules.
+			return true, nil
+		}
+		if modifiers != nil {
+			if err := r.ParseModifiers(modifiers); err != nil {
+				return false, fmt.Errorf("parse modifiers: %v", err)
+			}
+		}
+		nr.exceptionStore.Insert(pattern, r)
+
+		return true, nil
+	}
+
+	r := &rule.Rule{
+		RawRule:    rawRule,
+		FilterName: filterName,
+	}
+
+	pattern, modifiers, isRegexp := parseRuleParts(rawRule)
+	if isRegexp {
+		// This is a regexp rule.
+		// TODO: implement proper support for regexp rules.
+		return false, nil
+	}
+	if modifiers != nil {
+		if err := r.ParseModifiers(modifiers); err != nil {
+			return false, fmt.Errorf("parse modifiers: %v", err)
+		}
+	}
+	nr.primaryStore.Insert(pattern, r)
+
+	return false, nil
+}
+
+func parseRuleParts(rawRule string) (pattern string, modifiers []string, isRegexp bool) {
+	pattern, rawModifiers, found := strings.Cut(rawRule, "$")
+	isRegexp = pattern != "" && pattern[0] == '/' && pattern[len(pattern)-1] == '/'
+	if found {
+		modifiers = splitModifiers(rawModifiers)
+	}
+
+	return pattern, modifiers, isRegexp
+}
+
+// splitModifiers splits by unescaped commas.
+// Empty fields are preserved (like strings.Split).
+func splitModifiers(s string) []string {
+	var res []string
+	var b strings.Builder
+	escaped := false
+
+	for _, r := range s {
+		switch r {
+		case '\\':
+			if escaped {
+				b.WriteRune('\\')
+			}
+			escaped = !escaped
+		case ',':
+			if escaped {
+				b.WriteRune(',')
+				escaped = false
+			} else {
+				res = append(res, b.String())
+				b.Reset()
+			}
+		default:
+			if escaped {
+				b.WriteRune('\\')
+				escaped = false
+			}
+			b.WriteRune(r)
+		}
+	}
+
+	if escaped {
+		b.WriteRune('\\')
+	}
+	res = append(res, b.String())
+	return res
+}

--- a/internal/networkrules/parse.go
+++ b/internal/networkrules/parse.go
@@ -33,11 +33,13 @@ func (nr *NetworkRules) ParseRule(rawRule string, filterName *string) (isExcepti
 			}
 
 			pattern := fmt.Sprintf("||%s^", host)
-			nr.primaryStore.Insert(pattern, &rule.Rule{
+			if err := nr.primaryStore.Insert(pattern, &rule.Rule{
 				RawRule:    rawRule,
 				FilterName: filterName,
 				Document:   true,
-			})
+			}); err != nil {
+				return false, fmt.Errorf("insert hosts rule: %w", err)
+			}
 		}
 
 		return false, nil
@@ -49,18 +51,15 @@ func (nr *NetworkRules) ParseRule(rawRule string, filterName *string) (isExcepti
 			FilterName: filterName,
 		}
 
-		pattern, modifiers, isRegexp := parseRuleParts(rawRule[2:])
-		if isRegexp {
-			// This is a regexp rule.
-			// TODO: implement proper support for regexp rules.
-			return true, nil
-		}
+		pattern, modifiers := parseRuleParts(rawRule[2:])
 		if modifiers != nil {
 			if err := r.ParseModifiers(modifiers); err != nil {
 				return false, fmt.Errorf("parse modifiers: %v", err)
 			}
 		}
-		nr.exceptionStore.Insert(pattern, r)
+		if err := nr.exceptionStore.Insert(pattern, r); err != nil {
+			return false, fmt.Errorf("insert exception rule: %w", err)
+		}
 
 		return true, nil
 	}
@@ -70,30 +69,70 @@ func (nr *NetworkRules) ParseRule(rawRule string, filterName *string) (isExcepti
 		FilterName: filterName,
 	}
 
-	pattern, modifiers, isRegexp := parseRuleParts(rawRule)
-	if isRegexp {
-		// This is a regexp rule.
-		// TODO: implement proper support for regexp rules.
-		return false, nil
-	}
+	pattern, modifiers := parseRuleParts(rawRule)
 	if modifiers != nil {
 		if err := r.ParseModifiers(modifiers); err != nil {
 			return false, fmt.Errorf("parse modifiers: %v", err)
 		}
 	}
-	nr.primaryStore.Insert(pattern, r)
+	if err := nr.primaryStore.Insert(pattern, r); err != nil {
+		return false, fmt.Errorf("insert rule: %w", err)
+	}
 
 	return false, nil
 }
 
-func parseRuleParts(rawRule string) (pattern string, modifiers []string, isRegexp bool) {
+// parseRuleParts splits rawRule into its pattern and modifier list.
+func parseRuleParts(rawRule string) (pattern string, modifiers []string) {
+	if pattern, modifiers, ok := parseRegexpRuleParts(rawRule); ok {
+		return pattern, modifiers
+	}
+
 	pattern, rawModifiers, found := strings.Cut(rawRule, "$")
-	isRegexp = pattern != "" && pattern[0] == '/' && pattern[len(pattern)-1] == '/'
 	if found {
 		modifiers = splitModifiers(rawModifiers)
 	}
+	return pattern, modifiers
+}
 
-	return pattern, modifiers, isRegexp
+// parseRegexpRuleParts splits a slash-delimited regexp rule into its pattern and modifier list.
+// Reports ok only if the rule looks like a regexp rule.
+func parseRegexpRuleParts(rawRule string) (pattern string, modifiers []string, ok bool) {
+	if len(rawRule) < 2 || rawRule[0] != '/' {
+		return "", nil, false
+	}
+
+	end := regexpPatternEnd(rawRule)
+	if end == -1 {
+		return "", nil, false
+	}
+
+	pattern = rawRule[:end+1]
+	if end+1 < len(rawRule) {
+		modifiers = splitModifiers(rawRule[end+2:])
+	}
+	return pattern, modifiers, true
+}
+
+func regexpPatternEnd(s string) int {
+	escaped := false
+	for i := 1; i < len(s); i++ {
+		switch s[i] {
+		case '\\':
+			escaped = !escaped
+		case '/':
+			if escaped {
+				escaped = false
+				continue
+			}
+			if i+1 == len(s) || s[i+1] == '$' { // End-of-string or modifier delimiter.
+				return i
+			}
+		default:
+			escaped = false
+		}
+	}
+	return -1
 }
 
 // splitModifiers splits by unescaped commas.

--- a/internal/networkrules/parse_test.go
+++ b/internal/networkrules/parse_test.go
@@ -1,0 +1,80 @@
+package networkrules
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestParseRuleParts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		rawRule       string
+		wantPattern   string
+		wantModifiers []string
+	}{
+		{
+			name:          "normal rule with modifiers",
+			rawRule:       "||example.com^$script",
+			wantPattern:   "||example.com^",
+			wantModifiers: []string{"script"},
+		},
+		{
+			name:          "regexp rule with dollar anchor",
+			rawRule:       `/foo$/$script`,
+			wantPattern:   `/foo$/`,
+			wantModifiers: []string{"script"},
+		},
+		{
+			name:          "empty pattern with modifiers",
+			rawRule:       "$script",
+			wantPattern:   "",
+			wantModifiers: []string{"script"},
+		},
+		{
+			name:          "regexp rule with escaped slash",
+			rawRule:       `/foo\/bar/$script`,
+			wantPattern:   `/foo\/bar/`,
+			wantModifiers: []string{"script"},
+		},
+		{
+			name:          "regexp rule with unescaped slash",
+			rawRule:       `/example.com/[0-9a-z]*.php/$domain=example.com`,
+			wantPattern:   `/example.com/[0-9a-z]*.php/`,
+			wantModifiers: []string{"domain=example.com"},
+		},
+		{
+			name:          "regexp rule with regexp modifier",
+			rawRule:       `/^https:\/\/d[0-9a-z]{12,13}\.cloudfront\.net\/loader\.min\.js$/$script,third-party,header=etag:/^W\/"[0-9a-f]{32}"$/`,
+			wantPattern:   `/^https:\/\/d[0-9a-z]{12,13}\.cloudfront\.net\/loader\.min\.js$/`,
+			wantModifiers: []string{"script", "third-party", `header=etag:/^W\/"[0-9a-f]{32}"$/`},
+		},
+		{
+			name:          "slash-prefixed normal rule",
+			rawRule:       `/path/like/filter$script`,
+			wantPattern:   `/path/like/filter`,
+			wantModifiers: []string{"script"},
+		},
+		{
+			name:        "regexp rule without modifiers",
+			rawRule:     `/ads\d+/`,
+			wantPattern: `/ads\d+/`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("parses %s", tt.name), func(t *testing.T) {
+			t.Parallel()
+
+			gotPattern, gotModifiers := parseRuleParts(tt.rawRule)
+			if gotPattern != tt.wantPattern {
+				t.Errorf("pattern = %q, want %q", gotPattern, tt.wantPattern)
+			}
+			if !reflect.DeepEqual(gotModifiers, tt.wantModifiers) {
+				t.Errorf("modifiers = %#v, want %#v", gotModifiers, tt.wantModifiers)
+			}
+		})
+	}
+}

--- a/internal/networkrules/rulestore.go
+++ b/internal/networkrules/rulestore.go
@@ -29,9 +29,10 @@ func newRuleStore[T comparable]() *ruleStore[T] {
 
 func (s *ruleStore[T]) Insert(pattern string, v T) error {
 	// The pattern is either generic (empty), regexp, or regular.
-	if pattern == "" {
+	switch {
+	case pattern == "":
 		s.generic = append(s.generic, v)
-	} else if len(pattern) > 1 && pattern[0] == '/' && pattern[len(pattern)-1] == '/' {
+	case len(pattern) > 1 && pattern[0] == '/' && pattern[len(pattern)-1] == '/':
 		body := pattern[1 : len(pattern)-1]
 		if body == "" {
 			return fmt.Errorf("empty regexp rule")
@@ -44,7 +45,7 @@ func (s *ruleStore[T]) Insert(pattern string, v T) error {
 			regexp: re,
 			value:  v,
 		})
-	} else {
+	default:
 		s.tree.Insert(pattern, v)
 	}
 

--- a/internal/networkrules/rulestore.go
+++ b/internal/networkrules/rulestore.go
@@ -1,0 +1,39 @@
+package networkrules
+
+import (
+	"github.com/irbis-sh/zen-desktop/internal/ruletree"
+	"github.com/irbis-sh/zen-desktop/internal/trimslice"
+)
+
+type treeRuleStore[T comparable] struct {
+	tree    *ruletree.Tree[T]
+	generic []T
+}
+
+func newRuleStore[T comparable]() *treeRuleStore[T] {
+	return &treeRuleStore[T]{
+		tree: ruletree.New[T](),
+	}
+}
+
+func (s *treeRuleStore[T]) Insert(pattern string, v T) {
+	if pattern == "" {
+		s.generic = append(s.generic, v)
+		return
+	}
+
+	s.tree.Insert(pattern, v)
+}
+
+func (s *treeRuleStore[T]) Get(url string) []T {
+	matches := s.tree.Get(url)
+	res := make([]T, 0, len(s.generic)+len(matches))
+	res = append(res, s.generic...)
+	res = append(res, matches...)
+	return res
+}
+
+func (s *treeRuleStore[T]) Compact() {
+	s.generic = trimslice.TrimSlice(s.generic)
+	s.tree.Compact()
+}

--- a/internal/networkrules/rulestore.go
+++ b/internal/networkrules/rulestore.go
@@ -1,39 +1,71 @@
 package networkrules
 
 import (
+	"fmt"
+	"regexp"
+
 	"github.com/irbis-sh/zen-desktop/internal/ruletree"
 	"github.com/irbis-sh/zen-desktop/internal/trimslice"
 )
 
-type treeRuleStore[T comparable] struct {
-	tree    *ruletree.Tree[T]
+// ruleStore matches URLs against ad-block style patterns with associated data.
+type ruleStore[T comparable] struct {
+	tree *ruletree.Tree[T]
+	// generic is rules with an empty pattern, which match for every URL.
 	generic []T
+	regexp  []regexpRule[T]
 }
 
-func newRuleStore[T comparable]() *treeRuleStore[T] {
-	return &treeRuleStore[T]{
+type regexpRule[T comparable] struct {
+	regexp *regexp.Regexp
+	value  T
+}
+
+func newRuleStore[T comparable]() *ruleStore[T] {
+	return &ruleStore[T]{
 		tree: ruletree.New[T](),
 	}
 }
 
-func (s *treeRuleStore[T]) Insert(pattern string, v T) {
+func (s *ruleStore[T]) Insert(pattern string, v T) error {
+	// The pattern is either generic (empty), regexp, or regular.
 	if pattern == "" {
 		s.generic = append(s.generic, v)
-		return
+	} else if len(pattern) > 1 && pattern[0] == '/' && pattern[len(pattern)-1] == '/' {
+		body := pattern[1 : len(pattern)-1]
+		if body == "" {
+			return fmt.Errorf("empty regexp rule")
+		}
+		re, err := regexp.Compile(body)
+		if err != nil {
+			return fmt.Errorf("compile regexp rule: %w", err)
+		}
+		s.regexp = append(s.regexp, regexpRule[T]{
+			regexp: re,
+			value:  v,
+		})
+	} else {
+		s.tree.Insert(pattern, v)
 	}
 
-	s.tree.Insert(pattern, v)
+	return nil
 }
 
-func (s *treeRuleStore[T]) Get(url string) []T {
+func (s *ruleStore[T]) Get(url string) []T {
 	matches := s.tree.Get(url)
 	res := make([]T, 0, len(s.generic)+len(matches))
 	res = append(res, s.generic...)
 	res = append(res, matches...)
+	for _, rule := range s.regexp {
+		if rule.regexp.MatchString(url) {
+			res = append(res, rule.value)
+		}
+	}
 	return res
 }
 
-func (s *treeRuleStore[T]) Compact() {
+func (s *ruleStore[T]) Compact() {
 	s.generic = trimslice.TrimSlice(s.generic)
+	s.regexp = trimslice.TrimSlice(s.regexp)
 	s.tree.Compact()
 }

--- a/internal/ruletree/compact.go
+++ b/internal/ruletree/compact.go
@@ -1,11 +1,11 @@
 package ruletree
 
+import "github.com/irbis-sh/zen-desktop/internal/trimslice"
+
 // Compact shrinks internal slice capacities to reduce memory usage.
 func (t *Tree[T]) Compact() {
 	t.insertMu.Lock()
 	defer t.insertMu.Unlock()
-
-	t.generic = trimSlice(t.generic)
 
 	stack := []*node[T]{
 		t.anchorRoot,
@@ -18,11 +18,11 @@ func (t *Tree[T]) Compact() {
 		stack = stack[:len(stack)-1]
 
 		if n.isLeaf() {
-			n.leaf = trimSlice(n.leaf)
+			n.leaf = trimslice.TrimSlice(n.leaf)
 		}
 
-		n.edges = trimSlice(n.edges)
-		n.prefix = trimSlice(n.prefix)
+		n.edges = trimslice.TrimSlice(n.edges)
+		n.prefix = trimslice.TrimSlice(n.prefix)
 
 		if n.wildcard != nil {
 			stack = append(stack, n.wildcard)
@@ -37,14 +37,4 @@ func (t *Tree[T]) Compact() {
 			stack = append(stack, e.node)
 		}
 	}
-}
-
-func trimSlice[T any](s []T) []T {
-	if len(s) == cap(s) {
-		return s
-	}
-
-	newSlice := make([]T, len(s))
-	copy(newSlice, s)
-	return newSlice
 }

--- a/internal/ruletree/ruletree.go
+++ b/internal/ruletree/ruletree.go
@@ -22,8 +22,6 @@ type Tree[T Data] struct {
 	domainBoundaryRoot *node[T]
 	// anchorRoot stores pattern beginning with tokenAnchor (|).
 	anchorRoot *node[T]
-	// generic is data without an associated pattern. It is returned for every Get call.
-	generic []T
 }
 
 func New[T Data]() *Tree[T] {
@@ -31,16 +29,12 @@ func New[T Data]() *Tree[T] {
 		root:               &node[T]{},
 		domainBoundaryRoot: &node[T]{},
 		anchorRoot:         &node[T]{},
-		generic:            make([]T, 0),
 	}
 }
 
 // Insert adds a pattern with associated data to the tree.
 func (t *Tree[T]) Insert(pattern string, v T) {
 	if pattern == "" {
-		t.insertMu.Lock()
-		t.generic = append(t.generic, v)
-		t.insertMu.Unlock()
 		return
 	}
 
@@ -162,11 +156,10 @@ func (t *Tree[T]) Get(url string) []T {
 		}
 	}
 
-	result := make([]T, len(t.generic)+len(data))
-	copy(result, t.generic)
+	result := make([]T, len(data))
 	var i int
 	for d := range data {
-		result[len(t.generic)+i] = d
+		result[i] = d
 		i++
 	}
 	return result

--- a/internal/ruletree/ruletree_test.go
+++ b/internal/ruletree/ruletree_test.go
@@ -357,37 +357,18 @@ func TestPatternMatching(t *testing.T) {
 		})
 	})
 
-	t.Run("generic matching", func(t *testing.T) {
+	t.Run("empty pattern is ignored", func(t *testing.T) {
 		t.Parallel()
 
-		t.Run("singular", func(t *testing.T) {
-			t.Parallel()
+		tr := New[string]()
+		tr.Insert("", "")
 
-			tr := New[string]()
-			tr.Insert("", "")
+		got := tr.Get("https://example.com")
+		want := []string{}
 
-			got := tr.Get("https://example.com")
-			want := []string{""}
-
-			if !equalSets(got, want) {
-				t.Fatalf("got=%v, want=%v", got, want)
-			}
-		})
-
-		t.Run("multiple", func(t *testing.T) {
-			t.Parallel()
-
-			tr := New[string]()
-			tr.Insert("", "")
-			tr.Insert("|https://example.com", "|https://example.com")
-			tr.Insert("||example.com", "||example.com")
-
-			got := tr.Get("https://example.com")
-			want := []string{"", "|https://example.com", "||example.com"}
-			if !equalSets(got, want) {
-				t.Fatalf("got=%v, want=%v", got, want)
-			}
-		})
+		if !equalSets(got, want) {
+			t.Fatalf("got=%v, want=%v", got, want)
+		}
 	})
 
 	t.Run("complex rule intersections", func(t *testing.T) {

--- a/internal/trimslice/trimslice.go
+++ b/internal/trimslice/trimslice.go
@@ -1,0 +1,16 @@
+package trimslice
+
+// TrimSlice returns a slice with the same elements as s, and no spare capacity.
+// If s already has capacity equal to its length, TrimSlice returns s unchanged.
+//
+// Use it for long-lived slices after appends are complete to let the GC reclaim
+// unused backing-array storage.
+func TrimSlice[T any](s []T) []T {
+	if len(s) == cap(s) {
+		return s
+	}
+
+	newS := make([]T, len(s))
+	copy(newS, s)
+	return newS
+}

--- a/internal/trimslice/trimslice_test.go
+++ b/internal/trimslice/trimslice_test.go
@@ -1,0 +1,37 @@
+package trimslice
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+)
+
+var lens = []int{
+	0, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610, 987, 1597, 2584, 4181, 6765, 10946, 17711, 28657, 46368, 75025, 121393, 196418,
+}
+
+func TestTrimSlice(t *testing.T) {
+	t.Parallel()
+
+	for _, l := range lens {
+		t.Run(fmt.Sprintf("len %d", l), func(t *testing.T) {
+			t.Parallel()
+
+			var s []int
+			for i := range l {
+				s = append(s, i)
+			}
+
+			got := TrimSlice(s)
+			if len(got) != len(s) {
+				t.Fatalf("len = %d, want %d", len(got), len(s))
+			}
+			if cap(got) != len(s) {
+				t.Fatalf("cap = %d, want %d", cap(got), len(s))
+			}
+			if !slices.Equal(got, s) {
+				t.Fatal("slices not equal")
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Implements regexp rule support in `networkrules`. Refactors the package by abstracting rule storage into `ruleStore`.

### How did you verify your code works?

New automated tests and some manual testing.

### What are the relevant issues?

Closes #681