### PR TITLE
internal/networkrules: fix hosts-rule allowlist exceptions

### DIFF
--- a/internal/networkrules/hosts_allowlist_test.go
+++ b/internal/networkrules/hosts_allowlist_test.go
@@ -1,0 +1,48 @@
+package networkrules
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHostsAllowlistRuleCancelsHostsBlock(t *testing.T) {
+	t.Parallel()
+
+	nr := New()
+
+	isException, err := nr.ParseRule("0.0.0.0 example.com", nil)
+	if err != nil {
+		t.Fatalf("ParseRule(hosts) error: %v", err)
+	}
+	if isException {
+		t.Fatal("hosts rule unexpectedly parsed as exception")
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "https://example.com", nil)
+	req.Header.Set("Sec-Fetch-User", "?1")
+	req.Header.Set("Sec-Fetch-Dest", "document")
+
+	_, blocked, _ := nr.ModifyReq(req)
+	if !blocked {
+		t.Fatal("expected hosts rule to block request")
+	}
+
+	filterName := "Allowlist"
+	isException, err = nr.ParseRule("@@0.0.0.0 example.com", &filterName)
+	if err != nil {
+		t.Fatalf("ParseRule(hosts exception) error: %v", err)
+	}
+	if !isException {
+		t.Fatal("hosts exception was not parsed as exception")
+	}
+
+	allowedReq := httptest.NewRequest(http.MethodGet, "https://example.com", nil)
+	allowedReq.Header.Set("Sec-Fetch-User", "?1")
+	allowedReq.Header.Set("Sec-Fetch-Dest", "document")
+
+	_, blocked, _ = nr.ModifyReq(allowedReq)
+	if blocked {
+		t.Fatal("expected hosts exception to allow request")
+	}
+}

--- a/internal/networkrules/parse.go
+++ b/internal/networkrules/parse.go
@@ -57,6 +57,30 @@ func (nr *NetworkRules) ParseRule(rawRule string, filterName *string) (isExcepti
 				return false, fmt.Errorf("parse modifiers: %v", err)
 			}
 		}
+
+		if matches := reHosts.FindStringSubmatch(pattern); matches != nil {
+			hostsField := matches[1]
+			if commentIndex := strings.IndexByte(hostsField, '#'); commentIndex != -1 {
+				hostsField = hostsField[:commentIndex]
+			}
+
+			hosts := strings.Fields(hostsField)
+			r.Document = true
+
+			for _, host := range hosts {
+				if reHostsIgnore.MatchString(host) {
+					continue
+				}
+
+				hostPattern := fmt.Sprintf("||%s^", host)
+				if err := nr.exceptionStore.Insert(hostPattern, r); err != nil {
+					return false, fmt.Errorf("insert hosts exception rule: %w", err)
+				}
+			}
+
+			return true, nil
+		}
+
 		if err := nr.exceptionStore.Insert(pattern, r); err != nil {
 			return false, fmt.Errorf("insert exception rule: %w", err)
 		}


### PR DESCRIPTION
### What does this PR do?

Fixes allowlisting for hosts rules from the block page flow.

When the block page sends `@@0.0.0.0 example.com`, the parser used to store it as a plain exception pattern (`0.0.0.0 example.com`), which does not match the hosts-based blocking pattern (`||example.com^`). This change detects hosts syntax in exception rules too, maps each host to `||host^`, and inserts those into the exception store.

Also adds a regression test (`TestHostsAllowlistRuleCancelsHostsBlock`) that reproduces the issue and verifies the allowlist exception unblocks the request.

### How did you verify your code works?

- added `TestHostsAllowlistRuleCancelsHostsBlock` under `internal/networkrules`
- attempted to run `go test ./internal/networkrules`, but the current Windows runner does not have `go` installed (`go: The term 'go' is not recognized`)

### What are the relevant issues?

Closes #686