### PR TITLE
Refactor `ExceptionRule` to embed `Rule`

### DIFF
--- a/internal/networkrules/exceptionrule/exceptionrule.go
+++ b/internal/networkrules/exceptionrule/exceptionrule.go
@@ -1,35 +1,13 @@
 package exceptionrule
 
 import (
-	"errors"
-	"fmt"
-	"log"
 	"net/http"
-	"strings"
 
 	"github.com/irbis-sh/zen-desktop/internal/networkrules/rule"
-	"github.com/irbis-sh/zen-desktop/internal/networkrules/rulemodifiers"
 )
 
 type ExceptionRule struct {
-	RawRule    string
-	FilterName *string
-
-	Modifiers       ExceptionModifiers
-	ReqResModifiers []rulemodifiers.ReqResModifier
-	QueryModifiers  []rulemodifiers.QueryModifier
-	Document        bool
-}
-
-type ExceptionModifiers struct {
-	AndModifiers []exceptionModifier
-	OrModifiers  []exceptionModifier
-}
-
-type exceptionModifier interface {
-	Cancels(rulemodifiers.Modifier) bool
-	ShouldMatchReq(req *http.Request) bool
-	ShouldMatchRes(res *http.Response) bool
+	rule.Rule
 }
 
 func (er *ExceptionRule) Cancels(r *rule.Rule) bool {
@@ -37,11 +15,11 @@ func (er *ExceptionRule) Cancels(r *rule.Rule) bool {
 		return false
 	}
 
-	if len(er.Modifiers.AndModifiers) == 0 && len(er.Modifiers.OrModifiers) == 0 && len(er.ReqResModifiers) == 0 && len(er.QueryModifiers) == 0 {
+	if len(er.MatchingModifiers.And) == 0 && len(er.MatchingModifiers.Or) == 0 && len(er.ReqResModifiers) == 0 && len(er.QueryModifiers) == 0 {
 		return true
 	}
 
-	for _, exc := range er.Modifiers.AndModifiers {
+	for _, exc := range er.MatchingModifiers.And {
 		found := false
 		for _, basic := range r.MatchingModifiers.And {
 			if exc.Cancels(basic) {
@@ -54,9 +32,9 @@ func (er *ExceptionRule) Cancels(r *rule.Rule) bool {
 		}
 	}
 
-	if len(er.Modifiers.OrModifiers) > 0 {
+	if len(er.MatchingModifiers.Or) > 0 {
 		found := false
-		for _, exc := range er.Modifiers.OrModifiers {
+		for _, exc := range er.MatchingModifiers.Or {
 			for _, basic := range r.MatchingModifiers.Or {
 				if exc.Cancels(basic) {
 					found = true
@@ -101,119 +79,12 @@ func (er *ExceptionRule) Cancels(r *rule.Rule) bool {
 	return true
 }
 
-func (er *ExceptionRule) ParseModifiers(modifiers []string) error {
-	for _, m := range modifiers {
-		if len(m) == 0 {
-			return errors.New("empty modifier")
-		}
-
-		isKind := func(kind string) bool {
-			if len(m) > 0 && m[0] == '~' {
-				return strings.HasPrefix(m[1:], kind)
-			}
-			return strings.HasPrefix(m, kind)
-		}
-		if isKind("document") || isKind("doc") {
-			er.Document = true
-			continue
-		}
-
-		var modifier rulemodifiers.Modifier
-		isOr := false
-		switch {
-		case isKind("domain"):
-			modifier = &rulemodifiers.DomainModifier{}
-		case isKind("method"):
-			modifier = &rulemodifiers.MethodModifier{}
-		case isKind("xmlhttprequest"),
-			isKind("xhr"),
-			isKind("font"),
-			isKind("subdocument"),
-			isKind("image"),
-			isKind("object"),
-			isKind("script"),
-			isKind("stylesheet"),
-			isKind("media"),
-			isKind("other"):
-			modifier = &rulemodifiers.ContentTypeModifier{}
-			isOr = true
-		case isKind("third-party"):
-			modifier = &rulemodifiers.ThirdPartyModifier{}
-		case isKind("removeparam"):
-			modifier = &rulemodifiers.RemoveParamModifier{}
-		case isKind("header"):
-			modifier = &rulemodifiers.HeaderModifier{}
-		case isKind("removeheader"):
-			modifier = &rulemodifiers.RemoveHeaderModifier{}
-		case isKind("all"):
-			// TODO: should act as "popup" modifier once it gets implemented
-			continue
-		default:
-			return fmt.Errorf("unknown modifier %s", m)
-		}
-
-		if err := modifier.Parse(m); err != nil {
-			return err
-		}
-
-		switch typed := modifier.(type) {
-		case exceptionModifier:
-			if isOr {
-				er.Modifiers.OrModifiers = append(er.Modifiers.OrModifiers, typed)
-			} else {
-				er.Modifiers.AndModifiers = append(er.Modifiers.AndModifiers, typed)
-			}
-		case rulemodifiers.ReqResModifier:
-			er.ReqResModifiers = append(er.ReqResModifiers, typed)
-		case rulemodifiers.QueryModifier:
-			er.QueryModifiers = append(er.QueryModifiers, typed)
-		default:
-			log.Fatalf("got unknown modifier type %T for modifier %s", modifier, m)
-		}
-
-	}
-
-	return nil
-}
-
 // ShouldMatchReq returns true if the rule should match the request.
 func (er *ExceptionRule) ShouldMatchReq(req *http.Request) bool {
-	// AndModifiers: All must match.
-	for _, m := range er.Modifiers.AndModifiers {
-		if !m.ShouldMatchReq(req) {
-			return false
-		}
-	}
-
-	// OrModifiers: At least one must match.
-	if len(er.Modifiers.OrModifiers) > 0 {
-		for _, m := range er.Modifiers.OrModifiers {
-			if m.ShouldMatchReq(req) {
-				return true
-			}
-		}
-		return false
-	}
-
-	return true
+	return er.ModifiersMatchReq(req)
 }
 
 // ShouldMatchRes returns true if the rule should match the response.
 func (er *ExceptionRule) ShouldMatchRes(res *http.Response) bool {
-	for _, m := range er.Modifiers.AndModifiers {
-		if !m.ShouldMatchRes(res) {
-			return false
-		}
-	}
-
-	if len(er.Modifiers.OrModifiers) > 0 {
-		for _, m := range er.Modifiers.OrModifiers {
-			if m.ShouldMatchRes(res) {
-				return true
-			}
-		}
-		return false
-	}
-
-	return true
+	return er.ModifiersMatchRes(res)
 }

--- a/internal/networkrules/exceptionrule/exceptionrule_test.go
+++ b/internal/networkrules/exceptionrule/exceptionrule_test.go
@@ -16,8 +16,10 @@ func TestExceptionRule(t *testing.T) {
 		filterName := "test"
 
 		er := &ExceptionRule{
-			RawRule:    "||example.com",
-			FilterName: &filterName,
+			Rule: rule.Rule{
+				RawRule:    "||example.com",
+				FilterName: &filterName,
+			},
 		}
 		r := &rule.Rule{
 			RawRule:    "||example.com$document",
@@ -37,8 +39,10 @@ func TestExceptionRule(t *testing.T) {
 		filterName := "test"
 
 		er := &ExceptionRule{
-			RawRule:    "||example.com$document",
-			FilterName: &filterName,
+			Rule: rule.Rule{
+				RawRule:    "||example.com$document",
+				FilterName: &filterName,
+			},
 		}
 		r := &rule.Rule{
 			RawRule:    "||example.com$document",
@@ -59,8 +63,10 @@ func TestExceptionRule(t *testing.T) {
 		filterName := "test"
 
 		er := &ExceptionRule{
-			RawRule:    "||example.com^$document",
-			FilterName: &filterName,
+			Rule: rule.Rule{
+				RawRule:    "||example.com^$document",
+				FilterName: &filterName,
+			},
 		}
 		r := &rule.Rule{
 			RawRule:    "||example.com",

--- a/internal/networkrules/networkrules_test.go
+++ b/internal/networkrules/networkrules_test.go
@@ -169,6 +169,138 @@ func TestRegexpRules(t *testing.T) {
 	})
 }
 
+func TestExceptionRules(t *testing.T) {
+	t.Parallel()
+
+	t.Run("generic exception cancels document primary", func(t *testing.T) {
+		t.Parallel()
+
+		nr := New()
+		if _, err := nr.ParseRule(`||example.com^$document`, nil); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := nr.ParseRule(`@@||example.com^`, nil); err != nil {
+			t.Fatal(err)
+		}
+
+		headers := http.Header{
+			"Sec-Fetch-Dest": []string{"document"},
+			"Sec-Fetch-User": []string{"?1"},
+		}
+		_, shouldBlock, _ := nr.ModifyReq(newTestRequest(t, "https://example.com/", headers))
+		if shouldBlock {
+			t.Fatal("expected generic exception to cancel document primary rule")
+		}
+	})
+
+	t.Run("exception cancels primary with matching request modifiers", func(t *testing.T) {
+		t.Parallel()
+
+		nr := New()
+		if _, err := nr.ParseRule(`||cdn.example/ad.js$script,domain=example.com`, nil); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := nr.ParseRule(`@@||cdn.example/ad.js$script,domain=example.com`, nil); err != nil {
+			t.Fatal(err)
+		}
+
+		headers := http.Header{
+			"Referer":        []string{"https://example.com/page"},
+			"Sec-Fetch-Dest": []string{"script"},
+		}
+		_, shouldBlock, _ := nr.ModifyReq(newTestRequest(t, "https://cdn.example/ad.js", headers))
+		if shouldBlock {
+			t.Fatal("expected exception to cancel primary rule with matching request modifiers")
+		}
+	})
+
+	t.Run("exception does not cancel a different content type", func(t *testing.T) {
+		t.Parallel()
+
+		nr := New()
+		if _, err := nr.ParseRule(`||example.com/ad$script`, nil); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := nr.ParseRule(`@@||example.com/ad$image`, nil); err != nil {
+			t.Fatal(err)
+		}
+
+		headers := http.Header{"Sec-Fetch-Dest": []string{"script"}}
+		_, shouldBlock, _ := nr.ModifyReq(newTestRequest(t, "https://example.com/ad", headers))
+		if !shouldBlock {
+			t.Fatal("expected primary rule to block when exception is for a different content type")
+		}
+	})
+
+	t.Run("single exception cancels multiple primary rules", func(t *testing.T) {
+		t.Parallel()
+
+		nr := New()
+		if _, err := nr.ParseRule(`||example.com/ad.js$script`, nil); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := nr.ParseRule(`||example.com/ad.js$script,third-party`, nil); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := nr.ParseRule(`@@||example.com/ad.js$script`, nil); err != nil {
+			t.Fatal(err)
+		}
+
+		headers := http.Header{
+			"Sec-Fetch-Dest": []string{"script"},
+			"Sec-Fetch-Site": []string{"cross-site"},
+		}
+		_, shouldBlock, _ := nr.ModifyReq(newTestRequest(t, "https://example.com/ad.js", headers))
+		if shouldBlock {
+			t.Fatal("expected single exception to cancel every matching primary rule")
+		}
+	})
+
+	t.Run("exception cancels query modification", func(t *testing.T) {
+		t.Parallel()
+
+		nr := New()
+		if _, err := nr.ParseRule(`||example.com^$removeparam=utm_source`, nil); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := nr.ParseRule(`@@||example.com^$removeparam=utm_source`, nil); err != nil {
+			t.Fatal(err)
+		}
+
+		_, shouldBlock, redirectURL := nr.ModifyReq(newTestRequest(t, "https://example.com/?utm_source=ad&id=1", nil))
+		if shouldBlock {
+			t.Fatal("expected query modification rule not to block")
+		}
+		if redirectURL != "" {
+			t.Fatalf("redirect URL = %q, want empty", redirectURL)
+		}
+	})
+
+	t.Run("exception cancels response modification", func(t *testing.T) {
+		t.Parallel()
+
+		nr := New()
+		if _, err := nr.ParseRule(`||example.com/tracking.js$removeheader=X-Test`, nil); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := nr.ParseRule(`@@||example.com/tracking.js$removeheader=X-Test`, nil); err != nil {
+			t.Fatal(err)
+		}
+
+		res := &http.Response{Header: http.Header{"X-Test": []string{"1"}}}
+		applied, err := nr.ModifyRes(newTestRequest(t, "https://example.com/tracking.js", nil), res)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(applied) != 0 {
+			t.Fatalf("applied rules = %d, want 0", len(applied))
+		}
+		if res.Header.Get("X-Test") != "1" {
+			t.Fatal("expected response header to be preserved")
+		}
+	})
+}
+
 func newTestRequest(t *testing.T, rawURL string, headers http.Header) *http.Request {
 	t.Helper()
 

--- a/internal/networkrules/parse.go
+++ b/internal/networkrules/parse.go
@@ -47,8 +47,10 @@ func (nr *NetworkRules) ParseRule(rawRule string, filterName *string) (isExcepti
 
 	if strings.HasPrefix(rawRule, "@@") {
 		r := &exceptionrule.ExceptionRule{
-			RawRule:    rawRule,
-			FilterName: filterName,
+			Rule: rule.Rule{
+				RawRule:    rawRule,
+				FilterName: filterName,
+			},
 		}
 
 		pattern, modifiers := parseRuleParts(rawRule[2:])

--- a/internal/networkrules/rule/rule.go
+++ b/internal/networkrules/rule/rule.go
@@ -121,6 +121,11 @@ func (rm *Rule) ShouldMatchReq(req *http.Request) bool {
 		return false
 	}
 
+	return rm.ModifiersMatchReq(req)
+}
+
+// ModifiersMatchReq returns true if the rule's matching modifiers match the request.
+func (rm *Rule) ModifiersMatchReq(req *http.Request) bool {
 	// AndModifiers: All must match.
 	for _, m := range rm.MatchingModifiers.And {
 		if !m.ShouldMatchReq(req) {
@@ -143,7 +148,11 @@ func (rm *Rule) ShouldMatchReq(req *http.Request) bool {
 
 // ShouldMatchRes returns true if the rule should match the response.
 func (rm *Rule) ShouldMatchRes(res *http.Response) bool {
-	// maybe add sec-fetch logic too
+	return rm.ModifiersMatchRes(res)
+}
+
+// ModifiersMatchRes returns true if the rule's matching modifiers match the response.
+func (rm *Rule) ModifiersMatchRes(res *http.Response) bool {
 	for _, m := range rm.MatchingModifiers.And {
 		if !m.ShouldMatchRes(res) {
 			return false


### PR DESCRIPTION
### What does this PR do?

Refactors/streamlines modifier parsing and matching in `ExceptionRule` by embedding `Rule`. Adds exception rule test coverage to the `NetworkRules` test suite.

### How did you verify your code works?

New and existing unit tests.

### What are the relevant issues?

<!--
**Please link any relevant issues**, for example:

Closes #123
-->
