### PR TITLE
internal/networkrules: rename modifier types

### DIFF
--- a/internal/networkrules/exceptionrule/exceptionrule.go
+++ b/internal/networkrules/exceptionrule/exceptionrule.go
@@ -15,13 +15,13 @@ func (er *ExceptionRule) Cancels(r *rule.Rule) bool {
 		return false
 	}
 
-	if len(er.MatchingModifiers.And) == 0 && len(er.MatchingModifiers.Or) == 0 && len(er.ReqResModifiers) == 0 && len(er.QueryModifiers) == 0 {
+	if len(er.ConditionModifiers.And) == 0 && len(er.ConditionModifiers.Or) == 0 && len(er.ActionModifiers) == 0 && len(er.QueryModifiers) == 0 {
 		return true
 	}
 
-	for _, exc := range er.MatchingModifiers.And {
+	for _, exc := range er.ConditionModifiers.And {
 		found := false
-		for _, basic := range r.MatchingModifiers.And {
+		for _, basic := range r.ConditionModifiers.And {
 			if exc.Cancels(basic) {
 				found = true
 				break
@@ -32,10 +32,10 @@ func (er *ExceptionRule) Cancels(r *rule.Rule) bool {
 		}
 	}
 
-	if len(er.MatchingModifiers.Or) > 0 {
+	if len(er.ConditionModifiers.Or) > 0 {
 		found := false
-		for _, exc := range er.MatchingModifiers.Or {
-			for _, basic := range r.MatchingModifiers.Or {
+		for _, exc := range er.ConditionModifiers.Or {
+			for _, basic := range r.ConditionModifiers.Or {
 				if exc.Cancels(basic) {
 					found = true
 					break
@@ -50,9 +50,9 @@ func (er *ExceptionRule) Cancels(r *rule.Rule) bool {
 		}
 	}
 
-	for _, exc := range er.ReqResModifiers {
+	for _, exc := range er.ActionModifiers {
 		found := false
-		for _, basic := range r.ReqResModifiers {
+		for _, basic := range r.ActionModifiers {
 			if exc.Cancels(basic) {
 				found = true
 				break

--- a/internal/networkrules/rule/rule.go
+++ b/internal/networkrules/rule/rule.go
@@ -19,19 +19,19 @@ type Rule struct {
 	// FilterName is the name of the filter that the rule belongs to.
 	FilterName *string
 
-	MatchingModifiers matchingModifiers
-	ReqResModifiers   []rulemodifiers.ReqResModifier
-	QueryModifiers    []rulemodifiers.QueryModifier
+	ConditionModifiers conditionModifiers
+	ActionModifiers    []rulemodifiers.ActionModifier
+	QueryModifiers     []rulemodifiers.QueryModifier
 
 	// Document shows if rule has Document modifier.
 	Document bool
 }
 
-type matchingModifiers struct {
+type conditionModifiers struct {
 	// And are modifiers that must all match for the rule to apply.
-	And []rulemodifiers.MatchingModifier
+	And []rulemodifiers.ConditionModifier
 	// Or are modifiers where at least one must match for the rule to apply.
-	Or []rulemodifiers.MatchingModifier
+	Or []rulemodifiers.ConditionModifier
 }
 
 func (rm *Rule) ParseModifiers(modifiers []string) error {
@@ -97,14 +97,14 @@ func (rm *Rule) ParseModifiers(modifiers []string) error {
 		}
 
 		switch typed := modifier.(type) {
-		case rulemodifiers.MatchingModifier:
+		case rulemodifiers.ConditionModifier:
 			if isOr {
-				rm.MatchingModifiers.Or = append(rm.MatchingModifiers.Or, typed)
+				rm.ConditionModifiers.Or = append(rm.ConditionModifiers.Or, typed)
 			} else {
-				rm.MatchingModifiers.And = append(rm.MatchingModifiers.And, typed)
+				rm.ConditionModifiers.And = append(rm.ConditionModifiers.And, typed)
 			}
-		case rulemodifiers.ReqResModifier:
-			rm.ReqResModifiers = append(rm.ReqResModifiers, typed)
+		case rulemodifiers.ActionModifier:
+			rm.ActionModifiers = append(rm.ActionModifiers, typed)
 		case rulemodifiers.QueryModifier:
 			rm.QueryModifiers = append(rm.QueryModifiers, typed)
 		default:
@@ -127,15 +127,15 @@ func (rm *Rule) ShouldMatchReq(req *http.Request) bool {
 // ModifiersMatchReq returns true if the rule's matching modifiers match the request.
 func (rm *Rule) ModifiersMatchReq(req *http.Request) bool {
 	// AndModifiers: All must match.
-	for _, m := range rm.MatchingModifiers.And {
+	for _, m := range rm.ConditionModifiers.And {
 		if !m.ShouldMatchReq(req) {
 			return false
 		}
 	}
 
 	// OrModifiers: At least one must match.
-	if len(rm.MatchingModifiers.Or) > 0 {
-		for _, m := range rm.MatchingModifiers.Or {
+	if len(rm.ConditionModifiers.Or) > 0 {
+		for _, m := range rm.ConditionModifiers.Or {
 			if m.ShouldMatchReq(req) {
 				return true
 			}
@@ -153,14 +153,14 @@ func (rm *Rule) ShouldMatchRes(res *http.Response) bool {
 
 // ModifiersMatchRes returns true if the rule's matching modifiers match the response.
 func (rm *Rule) ModifiersMatchRes(res *http.Response) bool {
-	for _, m := range rm.MatchingModifiers.And {
+	for _, m := range rm.ConditionModifiers.And {
 		if !m.ShouldMatchRes(res) {
 			return false
 		}
 	}
 
-	if len(rm.MatchingModifiers.Or) > 0 {
-		for _, m := range rm.MatchingModifiers.Or {
+	if len(rm.ConditionModifiers.Or) > 0 {
+		for _, m := range rm.ConditionModifiers.Or {
 			if m.ShouldMatchRes(res) {
 				return true
 			}
@@ -173,12 +173,12 @@ func (rm *Rule) ModifiersMatchRes(res *http.Response) bool {
 
 // ShouldBlockReq returns true if the request should be blocked.
 func (rm *Rule) ShouldBlockReq(*http.Request) bool {
-	return len(rm.ReqResModifiers) == 0 && len(rm.QueryModifiers) == 0
+	return len(rm.ActionModifiers) == 0 && len(rm.QueryModifiers) == 0
 }
 
 // ModifyReq modifies a request. Returns true if the request was modified.
 func (rm *Rule) ModifyReq(req *http.Request) (modified bool) {
-	for _, modifier := range rm.ReqResModifiers {
+	for _, modifier := range rm.ActionModifiers {
 		if modifier.ModifyReq(req) {
 			modified = true
 		}
@@ -200,7 +200,7 @@ func (rm *Rule) ModifyReqQuery(query url.Values) (modified bool) {
 
 // ModifyRes modifies a response. Returns true if the response was modified.
 func (rm *Rule) ModifyRes(res *http.Response) (modified bool, err error) {
-	for _, modifier := range rm.ReqResModifiers {
+	for _, modifier := range rm.ActionModifiers {
 		m, err := modifier.ModifyRes(res)
 		if err != nil {
 			return false, fmt.Errorf("modify response: %w", err)

--- a/internal/networkrules/rulemodifiers/contenttype.go
+++ b/internal/networkrules/rulemodifiers/contenttype.go
@@ -9,7 +9,7 @@ type ContentTypeModifier struct {
 	inverted    bool
 }
 
-var _ MatchingModifier = (*ContentTypeModifier)(nil)
+var _ ConditionModifier = (*ContentTypeModifier)(nil)
 
 var (
 	// secFetchDestMap maps Sec-Fetch-Dest header values to corresponding content type modifiers.

--- a/internal/networkrules/rulemodifiers/domain.go
+++ b/internal/networkrules/rulemodifiers/domain.go
@@ -22,7 +22,7 @@ type DomainModifier struct {
 	inverted bool
 }
 
-var _ MatchingModifier = (*DomainModifier)(nil)
+var _ ConditionModifier = (*DomainModifier)(nil)
 
 func (m *DomainModifier) Parse(modifier string) error {
 	eqIndex := strings.IndexByte(modifier, '=')

--- a/internal/networkrules/rulemodifiers/header.go
+++ b/internal/networkrules/rulemodifiers/header.go
@@ -17,7 +17,7 @@ type HeaderModifier struct {
 	regexp *regexp.Regexp
 }
 
-var _ MatchingModifier = (*HeaderModifier)(nil)
+var _ ConditionModifier = (*HeaderModifier)(nil)
 
 func (h *HeaderModifier) Parse(modifier string) error {
 	if len(modifier) == 0 {

--- a/internal/networkrules/rulemodifiers/jsonprune.go
+++ b/internal/networkrules/rulemodifiers/jsonprune.go
@@ -16,7 +16,7 @@ type JSONPruneModifier struct {
 	commands []string
 }
 
-var _ ReqResModifier = (*JSONPruneModifier)(nil)
+var _ ActionModifier = (*JSONPruneModifier)(nil)
 
 var ErrInvalidJSONPruneModifier = errors.New("invalid jsonprune modifier")
 

--- a/internal/networkrules/rulemodifiers/method.go
+++ b/internal/networkrules/rulemodifiers/method.go
@@ -12,7 +12,7 @@ type MethodModifier struct {
 	inverted bool
 }
 
-var _ MatchingModifier = (*MethodModifier)(nil)
+var _ ConditionModifier = (*MethodModifier)(nil)
 
 func (m *MethodModifier) Parse(modifier string) error {
 	eqIndex := strings.IndexByte(modifier, '=')

--- a/internal/networkrules/rulemodifiers/removeheader.go
+++ b/internal/networkrules/rulemodifiers/removeheader.go
@@ -76,7 +76,7 @@ type RemoveHeaderModifier struct {
 	HeaderName string
 }
 
-var _ ReqResModifier = (*RemoveHeaderModifier)(nil)
+var _ ActionModifier = (*RemoveHeaderModifier)(nil)
 
 func (rm *RemoveHeaderModifier) Parse(modifier string) error {
 	if !strings.HasPrefix(modifier, "removeheader=") {

--- a/internal/networkrules/rulemodifiers/removejsconstant/removejsconstant.go
+++ b/internal/networkrules/rulemodifiers/removejsconstant/removejsconstant.go
@@ -20,7 +20,7 @@ type Modifier struct {
 	keys [][]string
 }
 
-var _ rulemodifiers.ReqResModifier = (*Modifier)(nil)
+var _ rulemodifiers.ActionModifier = (*Modifier)(nil)
 
 var removeJSConstantRegex = regexp.MustCompile(`^remove-js-constant=(.*)$`)
 
@@ -38,7 +38,7 @@ func (rc *Modifier) Parse(modifier string) error {
 	return nil
 }
 
-// ModifyReq implements [rulemodifiers.ReqResModifier].
+// ModifyReq implements [rulemodifiers.ActionModifier].
 func (*Modifier) ModifyReq(*http.Request) bool {
 	return false
 }

--- a/internal/networkrules/rulemodifiers/rulemodifiers.go
+++ b/internal/networkrules/rulemodifiers/rulemodifiers.go
@@ -11,21 +11,22 @@ type Modifier interface {
 	Cancels(Modifier) bool
 }
 
-// MatchingModifier defines whether a rule matches a request.
-type MatchingModifier interface {
+// ConditionModifier restrict when a rule applies based on request/response metadata.
+type ConditionModifier interface {
 	Modifier
 	ShouldMatchReq(*http.Request) bool
 	ShouldMatchRes(*http.Response) bool
 }
 
-// ReqResModifier modifies requests and responses.
-type ReqResModifier interface {
+// ActionModifier modifies requests and responses.
+type ActionModifier interface {
 	Modifier
 	ModifyReq(*http.Request) bool
 	ModifyRes(*http.Response) (bool, error)
 }
 
 // QueryModifier modifies request query parameters.
+// According to terminology, they are also "action modifiers", but are implemented separately for performance reasons.
 type QueryModifier interface {
 	Modifier
 	ModifyQuery(url.Values) bool

--- a/internal/networkrules/rulemodifiers/scramblejs.go
+++ b/internal/networkrules/rulemodifiers/scramblejs.go
@@ -19,7 +19,7 @@ type ScrambleJSModifier struct {
 	keys []*regexp.Regexp
 }
 
-var _ ReqResModifier = (*ScrambleJSModifier)(nil)
+var _ ActionModifier = (*ScrambleJSModifier)(nil)
 
 var scrambleJSRegex = regexp.MustCompile(`^scramblejs=(.+)$`)
 

--- a/internal/networkrules/rulemodifiers/thirdparty.go
+++ b/internal/networkrules/rulemodifiers/thirdparty.go
@@ -9,7 +9,7 @@ type ThirdPartyModifier struct {
 	inverted bool
 }
 
-var _ MatchingModifier = (*ThirdPartyModifier)(nil)
+var _ ConditionModifier = (*ThirdPartyModifier)(nil)
 
 func (m *ThirdPartyModifier) Parse(modifier string) error {
 	if modifier[0] == '~' {


### PR DESCRIPTION
### What does this PR do?

Makes modifier types and fields match the terminology present in docs: https://docs.irbis.sh/docs/zen/reference/engine/network-rules/#modifiers

### How did you verify your code works?

Existing automated testing.

### What are the relevant issues?

<!--
**Please link any relevant issues**, for example:

Closes #123
-->
