### PR TITLE
implement ShouldMatchRes for ContentTypeModifier

### DIFF
--- a/internal/networkrules/rulemodifiers/contenttype.go
+++ b/internal/networkrules/rulemodifiers/contenttype.go
@@ -75,14 +75,14 @@ func (m *ContentTypeModifier) ShouldMatchReq(req *http.Request) bool {
 	return contentType == m.contentType
 }
 
-func (m *ContentTypeModifier) ShouldMatchRes(req *http.Response) bool {
-	contentType := req.Header.Get("Content-Type")
+func (m *ContentTypeModifier) ShouldMatchRes(res *http.Response) bool {
+	contentType := res.Header.Get("Content-Type")
 	if contentType == "" {
 		return false
 	}
 
 	// strip parameters like charset
-	mimeType := strings.Split(contentType, ";")[0]
+	mimeType, _, _ := strings.Cut(contentType, ";")
 	mimeType = strings.TrimSpace(mimeType)
 	mimeType = strings.ToLower(mimeType)
 
@@ -108,8 +108,8 @@ func mapResponseContentTypeToModifier(mimeType string) (string, bool) {
 	}
 
 	// check tp-level type
-	parts := strings.SplitN(mimeType, "/", 2)
-	if top, ok := contentTypeMap[parts[0]]; ok {
+	before, _, _ := strings.Cut(mimeType, "/")
+	if top, ok := contentTypeMap[before]; ok {
 		return top, true
 	}
 

--- a/internal/networkrules/rulemodifiers/contenttype.go
+++ b/internal/networkrules/rulemodifiers/contenttype.go
@@ -2,6 +2,7 @@ package rulemodifiers
 
 import (
 	"net/http"
+	"strings"
 )
 
 type ContentTypeModifier struct {
@@ -63,8 +64,17 @@ func (m *ContentTypeModifier) ShouldMatchReq(req *http.Request) bool {
 	return contentType == m.contentType
 }
 
-func (m *ContentTypeModifier) ShouldMatchRes(_ *http.Response) bool {
-	return false
+func (m *ContentTypeModifier) ShouldMatchRes(req *http.Response) bool {
+	contentTypeRaw := req.Header.Get("Content-Type")
+	if contentTypeRaw == "" {
+		return false
+	}
+	contentType := strings.Split(contentTypeRaw, "/")[0]
+	if m.inverted {
+		return contentType != m.contentType
+	}
+
+	return contentType == m.contentType
 }
 
 func (m *ContentTypeModifier) Cancels(modifier Modifier) bool {

--- a/internal/networkrules/rulemodifiers/contenttype.go
+++ b/internal/networkrules/rulemodifiers/contenttype.go
@@ -85,6 +85,7 @@ func (m *ContentTypeModifier) ShouldMatchRes(req *http.Response) bool {
 	// strip parameters like charset
 	mimeType := strings.Split(contentType, ";")[0]
 	mimeType = strings.TrimSpace(mimeType)
+	mimeType = strings.ToLower(mimeType)
 
 	normalized, known := mapResponseContentTypeToModifier(mimeType)
 	if m.contentType == "other" {

--- a/internal/networkrules/rulemodifiers/contenttype.go
+++ b/internal/networkrules/rulemodifiers/contenttype.go
@@ -32,7 +32,7 @@ var (
 		"css": "stylesheet",
 		"xhr": "xmlhttprequest",
 	}
-
+	// contentTypeMap maps response Content-Type MIME types to the same modifier
 	contentTypeMap = map[string]string{
 		"text/css":               "stylesheet",
 		"text/javascript":        "script",

--- a/internal/networkrules/rulemodifiers/contenttype.go
+++ b/internal/networkrules/rulemodifiers/contenttype.go
@@ -32,6 +32,18 @@ var (
 		"css": "stylesheet",
 		"xhr": "xmlhttprequest",
 	}
+
+	contentTypeMap = map[string]string{
+		"text/css":               "stylesheet",
+		"text/javascript":        "script",
+		"application/javascript": "script",
+		"application/json":       "xmlhttprequest",
+		"image":                  "image",
+		"audio":                  "media",
+		"video":                  "media",
+		"font":                   "font",
+		"text/html":              "subdocument",
+	}
 )
 
 func (m *ContentTypeModifier) Parse(modifier string) error {
@@ -65,16 +77,43 @@ func (m *ContentTypeModifier) ShouldMatchReq(req *http.Request) bool {
 }
 
 func (m *ContentTypeModifier) ShouldMatchRes(req *http.Response) bool {
-	contentTypeRaw := req.Header.Get("Content-Type")
-	if contentTypeRaw == "" {
+	contentType := req.Header.Get("Content-Type")
+	if contentType == "" {
 		return false
 	}
-	contentType := strings.Split(contentTypeRaw, "/")[0]
-	if m.inverted {
-		return contentType != m.contentType
+
+	// strip parameters like charset
+	mimeType := strings.Split(contentType, ";")[0]
+	mimeType = strings.TrimSpace(mimeType)
+
+	normalized, known := mapResponseContentTypeToModifier(mimeType)
+	if m.contentType == "other" {
+		if m.inverted {
+			return known
+		}
+
+		return !known
 	}
 
-	return contentType == m.contentType
+	if m.inverted {
+		return normalized != m.contentType
+	}
+
+	return normalized == m.contentType
+}
+
+func mapResponseContentTypeToModifier(mimeType string) (string, bool) {
+	if mapped, ok := contentTypeMap[mimeType]; ok {
+		return mapped, true
+	}
+
+	// check tp-level type
+	parts := strings.SplitN(mimeType, "/", 2)
+	if top, ok := contentTypeMap[parts[0]]; ok {
+		return top, true
+	}
+
+	return "", false
 }
 
 func (m *ContentTypeModifier) Cancels(modifier Modifier) bool {

--- a/internal/networkrules/rulemodifiers/contenttype.go
+++ b/internal/networkrules/rulemodifiers/contenttype.go
@@ -32,7 +32,7 @@ var (
 		"css": "stylesheet",
 		"xhr": "xmlhttprequest",
 	}
-	// contentTypeMap maps response Content-Type MIME types to the same modifier
+	// contentTypeMap maps response Content-Type MIME types to the same modifier.
 	contentTypeMap = map[string]string{
 		"text/css":               "stylesheet",
 		"text/javascript":        "script",

--- a/internal/networkrules/rulemodifiers/contenttype.go
+++ b/internal/networkrules/rulemodifiers/contenttype.go
@@ -34,14 +34,18 @@ var (
 	}
 	// contentTypeMap maps response Content-Type MIME types to the same modifier.
 	contentTypeMap = map[string]string{
-		"text/css":               "stylesheet",
-		"text/javascript":        "script",
-		"application/javascript": "script",
-		"application/json":       "xmlhttprequest",
-		"image":                  "image",
-		"audio":                  "media",
-		"video":                  "media",
-		"font":                   "font",
+		"text/css":                      "stylesheet",
+		"text/javascript":               "script",
+		"application/javascript":        "script",
+		"application/json":              "xmlhttprequest",
+		"image":                         "image",
+		"audio":                         "media",
+		"video":                         "media",
+		"font":                          "font",
+		"text/html":                     "subdocument",
+		"application/pdf":               "object",
+		"application/x-shockwave-flash": "object",
+		"application/octet-stream":      "object",
 	}
 )
 
@@ -107,7 +111,7 @@ func mapResponseContentTypeToModifier(mimeType string) (string, bool) {
 		return mapped, true
 	}
 
-	// check tp-level type
+	// check top-level type
 	before, _, _ := strings.Cut(mimeType, "/")
 	if top, ok := contentTypeMap[before]; ok {
 		return top, true

--- a/internal/networkrules/rulemodifiers/contenttype.go
+++ b/internal/networkrules/rulemodifiers/contenttype.go
@@ -42,7 +42,6 @@ var (
 		"audio":                  "media",
 		"video":                  "media",
 		"font":                   "font",
-		"text/html":              "subdocument",
 	}
 )
 

--- a/internal/networkrules/rulemodifiers/contenttype_test.go
+++ b/internal/networkrules/rulemodifiers/contenttype_test.go
@@ -1,0 +1,84 @@
+package rulemodifiers
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestContentTypeModifier_ShouldMatchRes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("matches image/jpeg for image modifier", func(t *testing.T) {
+		t.Parallel()
+
+		m := &ContentTypeModifier{contentType: "image"}
+		res := &http.Response{
+			Header: http.Header{"Content-Type": []string{"image/jpeg"}},
+		}
+
+		if !m.ShouldMatchRes(res) {
+			t.Fatal("expected to match image/jpeg")
+		}
+	})
+
+	t.Run("does not match text/css for image modifier", func(t *testing.T) {
+		t.Parallel()
+		m := &ContentTypeModifier{contentType: "image"}
+		res := &http.Response{
+			Header: http.Header{"Content-Type": []string{"text/css"}},
+		}
+
+		if m.ShouldMatchRes(res) {
+			t.Fatal("expected not to match text/css")
+		}
+	})
+
+	t.Run("return false for empty Content-Type", func(t *testing.T) {
+		t.Parallel()
+
+		m := &ContentTypeModifier{contentType: "image"}
+		res := &http.Response{Header: http.Header{}}
+		if m.ShouldMatchRes(res) {
+			t.Fatal("expected false for empty Content-Type")
+		}
+	})
+
+	t.Run("inverted does not match image/jpeg", func(t *testing.T) {
+		t.Parallel()
+
+		m := &ContentTypeModifier{contentType: "image", inverted: true}
+		res := &http.Response{
+			Header: http.Header{"Content-Type": []string{"image/jpeg"}},
+		}
+
+		if m.ShouldMatchRes(res) {
+			t.Fatal("expected inverted not to match image/jpeg")
+		}
+	})
+
+	t.Run("matches text/css for stylesheet modifier", func(t *testing.T) {
+		t.Parallel()
+
+		m := &ContentTypeModifier{contentType: "stylesheet"}
+		res := &http.Response{
+			Header: http.Header{"Content-Type": []string{"text/css"}},
+		}
+
+		if !m.ShouldMatchRes(res) {
+			t.Fatal("expected to match text/css for stylesheet")
+		}
+	})
+
+	t.Run("other matches unknown content type", func(t *testing.T) {
+		t.Parallel()
+
+		m := &ContentTypeModifier{contentType: "other"}
+		res := &http.Response{
+			Header: http.Header{"Content-Type": []string{"application/weird"}},
+		}
+
+		if !m.ShouldMatchRes(res) {
+			t.Fatal("expected other to match unkwnow content type")
+		}
+	})
+}

--- a/internal/networkrules/rulemodifiers/contenttype_test.go
+++ b/internal/networkrules/rulemodifiers/contenttype_test.go
@@ -69,7 +69,7 @@ func TestContentTypeModifier_ShouldMatchRes(t *testing.T) {
 		}
 	})
 
-	t.Run("matches image/jpeg; with parameters and inverted", func(t *testing.T) {
+	t.Run("matches image/jpeg; with parameters", func(t *testing.T) {
 		t.Parallel()
 
 		m := &ContentTypeModifier{contentType: "image"}

--- a/internal/networkrules/rulemodifiers/contenttype_test.go
+++ b/internal/networkrules/rulemodifiers/contenttype_test.go
@@ -69,6 +69,32 @@ func TestContentTypeModifier_ShouldMatchRes(t *testing.T) {
 		}
 	})
 
+	t.Run("matches image/jpeg; with parameters and inverted", func(t *testing.T) {
+		t.Parallel()
+
+		m := &ContentTypeModifier{contentType: "image"}
+		res := &http.Response{
+			Header: http.Header{"Content-Type": []string{"image/jpeg; charset=utf-8"}},
+		}
+
+		if !m.ShouldMatchRes(res) {
+			t.Fatal("expected to match image/jpeg; charset=utf-8 for image")
+		}
+	})
+
+	t.Run("matches mixed-case Application/JSON", func(t *testing.T) {
+		t.Parallel()
+
+		m := &ContentTypeModifier{contentType: "xmlhttprequest"}
+		res := &http.Response{
+			Header: http.Header{"Content-Type": []string{"Application/JSON"}},
+		}
+
+		if !m.ShouldMatchRes(res) {
+			t.Fatal("expected to match Application/JSON for xmlhttprequest")
+		}
+	})
+
 	t.Run("other matches unknown content type", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/networkrules/rulemodifiers/contenttype_test.go
+++ b/internal/networkrules/rulemodifiers/contenttype_test.go
@@ -108,7 +108,7 @@ func TestContentTypeModifier_ShouldMatchRes(t *testing.T) {
 		}
 	})
 
-	t.Run("inverted other does not match known content type", func(t *testing.T) {
+	t.Run("inverted other matches known content type", func(t *testing.T) {
 		t.Parallel()
 		m := &ContentTypeModifier{contentType: "other", inverted: true}
 		res := &http.Response{

--- a/internal/networkrules/rulemodifiers/contenttype_test.go
+++ b/internal/networkrules/rulemodifiers/contenttype_test.go
@@ -104,7 +104,18 @@ func TestContentTypeModifier_ShouldMatchRes(t *testing.T) {
 		}
 
 		if !m.ShouldMatchRes(res) {
-			t.Fatal("expected other to match unkwnow content type")
+			t.Fatal("expected other to match unknown content type")
+		}
+	})
+
+	t.Run("inverted other does not match known content type", func(t *testing.T) {
+		t.Parallel()
+		m := &ContentTypeModifier{contentType: "other", inverted: true}
+		res := &http.Response{
+			Header: http.Header{"Content-Type": []string{"image/jpeg"}},
+		}
+		if !m.ShouldMatchRes(res) {
+			t.Fatal("expected inverted other to match known content type")
 		}
 	})
 }


### PR DESCRIPTION
## What does this PR do?

Implements `ShouldMatchRes` for `ContentTypeModifier`. 

Previously, the method always returned `false`, meaning content type matching only worked via the `Sec-Fetch-Dest` request header. This PR adds support for matching against the `Content-Type` response header, which is more reliable as it is always present in server responses.

## How did you verify your code works?

Manually verified that `ShouldMatchRes` correctly:
- Parses the `Content-Type` response header
- Matches the top-level type (e.g. `image` from `image/jpeg`)
- Returns `false` when `Content-Type` is empty
- Respects the `inverted` flag

## What are the relevant issues?

Closes #698