### PR TITLE
fix: cleanup whitelistSrv if StartProxy fails after initialization

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -218,6 +218,15 @@ func (a *App) StartProxy() (err error) {
 	}
 	a.whitelistSrv = whitelistSrv
 
+	defer func() {
+		if err != nil {
+			if err := whitelistSrv.Stop(); err != nil {
+				log.Printf("failed to stop whitelist server: %v", err)
+			}
+			a.whitelistSrv = nil
+		}
+	}()
+
 	routingPolicy := routing.NewPolicy(a.config.GetRouting())
 
 	a.proxy, err = proxy.NewProxy(filter, certGenerator, a.config.GetPort(), routingPolicy.ShouldProxy)


### PR DESCRIPTION
### What does this PR do?
If `StartProxy` fails after `whitelistSrv` has already been started,
the whitelist server is now properly stopped and `a.whitelistSrv` is
set to `nil`. This follows the same cleanup pattern already used for
`assetSrv`.

### How did you verify your code works?
Manual code review — the cleanup logic follows the existing pattern
for `assetSrv` cleanup in the same function.

### What are the relevant issues?
Closes #580