### PR TITLE
internal/cergen: remove x509.ExtKeyUsageClientAuth

### DIFF
--- a/internal/certgen/get.go
+++ b/internal/certgen/get.go
@@ -49,7 +49,7 @@ func (cg *CertGenerator) GetCertificate(host string) (*tls.Certificate, error) {
 		NotAfter:  notAfter,
 
 		KeyUsage:              x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 		BasicConstraintsValid: true,
 	}
 


### PR DESCRIPTION
### What does this PR do?

Remove `x509.ExtKeyUsageClientAuth` from the sequence of extended key usage for the generated host certificates. The generated certificates currently have no usage on the client side, therefore removing client-side extended key usage tightens the scope to the actual use case.

### How did you verify your code works?

Verified that the generated leaf certificates only include `x509.ExtKeyUsageServerAuth` via `openssl s_client`. Also, manually double checked that the generated certificates continue to be accepted in Chrome/Firefox on a Windows machine.

### What are the relevant issues?

Closes #709
