### PR TITLE
Implement Websocket Content Type Modifier

### DIFF
--- a/internal/networkrules/rule/rule.go
+++ b/internal/networkrules/rule/rule.go
@@ -63,6 +63,7 @@ func (rm *Rule) ParseModifiers(modifiers []string) error {
 				"script",
 				"stylesheet",
 				"media",
+				"websocket",
 				"other":
 				modifier = &rulemodifiers.ContentTypeModifier{}
 				isOr = true

--- a/internal/networkrules/rulemodifiers/contenttype.go
+++ b/internal/networkrules/rulemodifiers/contenttype.go
@@ -134,7 +134,6 @@ func (m *ContentTypeModifier) Cancels(modifier Modifier) bool {
 	return other.inverted == m.inverted && other.contentType == m.contentType
 }
 
-// mirror of proxy.headerContains
 func headerContains(h http.Header, name, value string) bool {
 	for _, v := range h[name] {
 		for _, s := range strings.Split(v, ",") {

--- a/internal/networkrules/rulemodifiers/contenttype.go
+++ b/internal/networkrules/rulemodifiers/contenttype.go
@@ -15,17 +15,18 @@ var _ ConditionModifier = (*ContentTypeModifier)(nil)
 var (
 	// secFetchDestMap maps Sec-Fetch-Dest header values to corresponding content type modifiers.
 	secFetchDestMap = map[string]string{
-		"empty":  "xmlhttprequest",
-		"font":   "font",
-		"frame":  "subdocument",
-		"iframe": "subdocument",
-		"image":  "image",
-		"object": "object",
-		"script": "script",
-		"style":  "stylesheet",
-		"audio":  "media",
-		"track":  "media",
-		"video":  "media",
+		"empty":     "xmlhttprequest",
+		"font":      "font",
+		"frame":     "subdocument",
+		"iframe":    "subdocument",
+		"image":     "image",
+		"object":    "object",
+		"script":    "script",
+		"style":     "stylesheet",
+		"audio":     "media",
+		"track":     "media",
+		"video":     "media",
+		"websocket": "websocket",
 	}
 	// aliases maps content type aliases to their canonical names.
 	aliases = map[string]string{
@@ -60,6 +61,14 @@ func (m *ContentTypeModifier) Parse(modifier string) error {
 func (m *ContentTypeModifier) ShouldMatchReq(req *http.Request) bool {
 	secFetchDest := req.Header.Get("Sec-Fetch-Dest")
 	if secFetchDest == "" {
+		if m.contentType == "websocket" {
+			isWS := headerContains(req.Header, "Connection", "upgrade") &&
+				headerContains(req.Header, "Upgrade", "websocket")
+			if m.inverted {
+				return !isWS
+			}
+			return isWS
+		}
 		return false
 	}
 	contentType, ok := secFetchDestMap[secFetchDest]
@@ -123,4 +132,16 @@ func (m *ContentTypeModifier) Cancels(modifier Modifier) bool {
 	}
 
 	return other.inverted == m.inverted && other.contentType == m.contentType
+}
+
+// mirror of proxy.headerContains
+func headerContains(h http.Header, name, value string) bool {
+	for _, v := range h[name] {
+		for _, s := range strings.Split(v, ",") {
+			if strings.EqualFold(strings.TrimSpace(s), value) {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/internal/networkrules/rulemodifiers/contenttype_test.go
+++ b/internal/networkrules/rulemodifiers/contenttype_test.go
@@ -5,6 +5,97 @@ import (
 	"testing"
 )
 
+func TestContentTypeModifier_ShouldMatchReq(t *testing.T) {
+	t.Parallel()
+
+	t.Run("matches websocket for websocket modifier", func(t *testing.T) {
+		t.Parallel()
+
+		m := &ContentTypeModifier{contentType: "websocket"}
+		req := &http.Request{
+			Header: http.Header{"Sec-Fetch-Dest": []string{"websocket"}},
+		}
+
+		if !m.ShouldMatchReq(req) {
+			t.Fatal("expected to match websocket")
+		}
+	})
+
+	t.Run("empty Sec-Fetch-Dest with connection upgrade matches websocket", func(t *testing.T) {
+		t.Parallel()
+
+		m := &ContentTypeModifier{contentType: "websocket"}
+		req := &http.Request{
+			Header: http.Header{"Connection": []string{"upgrade"}, "Upgrade": []string{"websocket"}},
+		}
+
+		if !m.ShouldMatchReq(req) {
+			t.Fatal("expected websocket connection upgrade to match websocket")
+		}
+	})
+
+	t.Run("does not match for connection upgrade with content-type != websocket", func(t *testing.T) {
+		t.Parallel()
+
+		m := &ContentTypeModifier{contentType: "image"}
+		req := &http.Request{
+			Header: http.Header{"Connection": []string{"upgrade"}, "Upgrade": []string{"websocket"}},
+		}
+
+		if m.ShouldMatchReq(req) {
+			t.Fatal("expected not to match wrong image modifier for connection upgrade")
+		}
+	})
+
+	t.Run("inverted websocket with no headers matches", func(t *testing.T) {
+		t.Parallel()
+
+		m := &ContentTypeModifier{contentType: "websocket", inverted: true}
+		req := &http.Request{}
+
+		if !m.ShouldMatchReq(req) {
+			t.Fatal("expected inverted with no header to match")
+		}
+	})
+
+	t.Run("empty Sec-Fetch-Dest and no connection upgrade does not match websocket", func(t *testing.T) {
+		t.Parallel()
+
+		m := &ContentTypeModifier{contentType: "websocket"}
+		req := &http.Request{}
+
+		if m.ShouldMatchReq(req) {
+			t.Fatal("expected not to match empty Sec-Fetch-Dest with no connection upgrade")
+		}
+	})
+
+	t.Run("inverted does not match websocket modifier", func(t *testing.T) {
+		t.Parallel()
+
+		m := &ContentTypeModifier{contentType: "websocket", inverted: true}
+		req := &http.Request{
+			Header: http.Header{"Sec-Fetch-Dest": []string{"websocket"}},
+		}
+
+		if m.ShouldMatchReq(req) {
+			t.Fatal("expected inverted not to match websocket")
+		}
+	})
+
+	t.Run("inverted with empty Sec-Fetch-Dest does not match", func(t *testing.T) {
+		t.Parallel()
+
+		m := &ContentTypeModifier{contentType: "websocket", inverted: true}
+		req := &http.Request{
+			Header: http.Header{"Connection": []string{"upgrade"}, "Upgrade": []string{"websocket"}},
+		}
+
+		if m.ShouldMatchReq(req) {
+			t.Fatal("expected inverted with empty Sec-Fetch-Dest not to match")
+		}
+	})
+}
+
 func TestContentTypeModifier_ShouldMatchRes(t *testing.T) {
 	t.Parallel()
 
@@ -23,6 +114,7 @@ func TestContentTypeModifier_ShouldMatchRes(t *testing.T) {
 
 	t.Run("does not match text/css for image modifier", func(t *testing.T) {
 		t.Parallel()
+
 		m := &ContentTypeModifier{contentType: "image"}
 		res := &http.Response{
 			Header: http.Header{"Content-Type": []string{"text/css"}},
@@ -110,10 +202,12 @@ func TestContentTypeModifier_ShouldMatchRes(t *testing.T) {
 
 	t.Run("inverted other matches known content type", func(t *testing.T) {
 		t.Parallel()
+
 		m := &ContentTypeModifier{contentType: "other", inverted: true}
 		res := &http.Response{
 			Header: http.Header{"Content-Type": []string{"image/jpeg"}},
 		}
+
 		if !m.ShouldMatchRes(res) {
 			t.Fatal("expected inverted other to match known content type")
 		}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -171,6 +171,12 @@ func (p *Proxy) proxyHTTP(w http.ResponseWriter, r *http.Request, processInfo pr
 		}
 	}
 
+	if _, ok := r.Header["User-Agent"]; !ok {
+		// If the outbound request doesn't have a User-Agent header set,
+		// don't send the default Go HTTP client User-Agent.
+		r.Header.Set("User-Agent", "")
+	}
+
 	if isWS(r) {
 		p.proxyWebsocket(w, r)
 		return
@@ -186,12 +192,6 @@ func (p *Proxy) proxyHTTP(w http.ResponseWriter, r *http.Request, processInfo pr
 
 	if teTrailers {
 		r.Header.Set("Te", "trailers")
-	}
-
-	if _, ok := r.Header["User-Agent"]; !ok {
-		// If the outbound request doesn't have a User-Agent header set,
-		// don't send the default Go HTTP client User-Agent.
-		r.Header.Set("User-Agent", "")
 	}
 
 	var (
@@ -346,6 +346,12 @@ func (p *Proxy) connectHandler(connReq *http.Request, host string, ln *singleCon
 			return
 		}
 
+		if _, ok := req.Header["User-Agent"]; !ok {
+			// If the outbound request doesn't have a User-Agent header set,
+			// don't send the default Go HTTP client User-Agent.
+			req.Header.Set("User-Agent", "")
+		}
+
 		// WebSocket upgrade is only done over HTTP/1.1.
 		if isWS(req) && req.ProtoMajor == 1 {
 			p.proxyWebsocketTLS(w, req)
@@ -360,12 +366,6 @@ func (p *Proxy) connectHandler(connReq *http.Request, host string, ln *singleCon
 
 		if teTrailers {
 			req.Header.Set("Te", "trailers")
-		}
-
-		if _, ok := req.Header["User-Agent"]; !ok {
-			// If the outbound request doesn't have a User-Agent header set,
-			// don't send the default Go HTTP client User-Agent.
-			req.Header.Set("User-Agent", "")
 		}
 
 		// Go's HTTP server always sets a non-nil value for req.Body.

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -333,7 +333,7 @@ func (p *Proxy) connectHandler(connReq *http.Request, host string, ln *singleCon
 		req.RequestURI = ""
 		req.Close = false
 
-		// Filter request, before upgrading to websockets, to match/block wss::// handshake
+		// Filter request, before upgrading to websockets, to match/block wss:// handshake
 		filterResp, err := p.filter.HandleRequest(req, processInfo)
 		if err != nil {
 			log.Printf("handling request for %q: %v", redacted.Redacted(req.URL), err)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -333,6 +333,19 @@ func (p *Proxy) connectHandler(connReq *http.Request, host string, ln *singleCon
 		req.RequestURI = ""
 		req.Close = false
 
+		// Filter request, before upgrading to websockets, to catch wss:://
+		filterResp, err := p.filter.HandleRequest(req, processInfo)
+		if err != nil {
+			log.Printf("handling request for %q: %v", redacted.Redacted(req.URL), err)
+		}
+		if filterResp != nil {
+			writeResp(w, filterResp)
+			if filterResp.Body != nil {
+				filterResp.Body.Close()
+			}
+			return
+		}
+
 		// WebSocket upgrade is only done over HTTP/1.1.
 		if isWS(req) && req.ProtoMajor == 1 {
 			p.proxyWebsocketTLS(w, req)
@@ -353,18 +366,6 @@ func (p *Proxy) connectHandler(connReq *http.Request, host string, ln *singleCon
 			// If the outbound request doesn't have a User-Agent header set,
 			// don't send the default Go HTTP client User-Agent.
 			req.Header.Set("User-Agent", "")
-		}
-
-		filterResp, err := p.filter.HandleRequest(req, processInfo)
-		if err != nil {
-			log.Printf("handling request for %q: %v", redacted.Redacted(req.URL), err)
-		}
-		if filterResp != nil {
-			writeResp(w, filterResp)
-			if filterResp.Body != nil {
-				filterResp.Body.Close()
-			}
-			return
 		}
 
 		// Go's HTTP server always sets a non-nil value for req.Body.

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -333,7 +333,7 @@ func (p *Proxy) connectHandler(connReq *http.Request, host string, ln *singleCon
 		req.RequestURI = ""
 		req.Close = false
 
-		// Filter request, before upgrading to websockets, to catch wss:://
+		// Filter request, before upgrading to websockets, to match/block wss::// handshake
 		filterResp, err := p.filter.HandleRequest(req, processInfo)
 		if err != nil {
 			log.Printf("handling request for %q: %v", redacted.Redacted(req.URL), err)


### PR DESCRIPTION
### What does this PR do?

This pull request introduces support for the `websocket` content type modifier. Previously, Zen disregarded the `websocket` modifier. Now it is registered and matched during the request process, while also being rejected by Zen's filter before upgrading to the websocket connection by returning `403` status code. 


### How did you verify your code works?

New test function `TestContentTypeModifier_ShouldMatchReq` is introduced in `contenttype_test.go` that verifies seven possible paths in `ContentTypeModifier.ShouldMatchReq` pertaining to the `websocket` modifier (both normal and inverted). 

Also double-checked that websocket connections are indeed blocked by adding the following custom rule: `||echo.websocket.org^$websocket` and tested against it via a custom Python script and browser console.

### What are the relevant issues?

Closes #720 