### PR TITLE
feat: implement ping content type modifier

### DIFF
--- a/internal/networkrules/rule/rule.go
+++ b/internal/networkrules/rule/rule.go
@@ -64,6 +64,7 @@ func (rm *Rule) ParseModifiers(modifiers []string) error {
 				"stylesheet",
 				"media",
 				"websocket",
+				"ping",
 				"other":
 				modifier = &rulemodifiers.ContentTypeModifier{}
 				isOr = true

--- a/internal/networkrules/rulemodifiers/contenttype.go
+++ b/internal/networkrules/rulemodifiers/contenttype.go
@@ -36,7 +36,6 @@ var (
 	// contentTypeMap maps Content-Type MIME types to corresponding content type modifiers.
 	contentTypeMap = map[string]string{
 		"text/css":                      "stylesheet",
-		"text/ping":                     "ping",
 		"text/javascript":               "script",
 		"application/javascript":        "script",
 		"image":                         "image",
@@ -60,7 +59,7 @@ func (m *ContentTypeModifier) Parse(modifier string) error {
 }
 
 func (m *ContentTypeModifier) ShouldMatchReq(req *http.Request) bool {
-	mimeType := m.getMimeType(req.Header)
+	mimeType := getMimeType(req.Header)
 
 	hasPingHeaders := req.Header.Get("Ping-To") != "" || req.Header.Get("Ping-From") != ""
 	isPing := hasPingHeaders && mimeType == "text/ping"
@@ -99,7 +98,7 @@ func (m *ContentTypeModifier) ShouldMatchReq(req *http.Request) bool {
 }
 
 func (m *ContentTypeModifier) ShouldMatchRes(res *http.Response) bool {
-	mimeType := m.getMimeType(res.Header)
+	mimeType := getMimeType(res.Header)
 
 	normalized, known := mapResponseContentTypeToModifier(mimeType)
 	if m.contentType == "other" {
@@ -151,7 +150,7 @@ func headerContains(h http.Header, name, value string) bool {
 	return false
 }
 
-func (m *ContentTypeModifier) getMimeType(header http.Header) string {
+func getMimeType(header http.Header) string {
 	contentType := header.Get("Content-Type")
 	if contentType == "" {
 		return ""

--- a/internal/networkrules/rulemodifiers/contenttype.go
+++ b/internal/networkrules/rulemodifiers/contenttype.go
@@ -36,6 +36,7 @@ var (
 	// contentTypeMap maps Content-Type MIME types to corresponding content type modifiers.
 	contentTypeMap = map[string]string{
 		"text/css":                      "stylesheet",
+		"text/ping":                     "ping",
 		"text/javascript":               "script",
 		"application/javascript":        "script",
 		"image":                         "image",
@@ -59,7 +60,7 @@ func (m *ContentTypeModifier) Parse(modifier string) error {
 }
 
 func (m *ContentTypeModifier) ShouldMatchReq(req *http.Request) bool {
-	mimeType := getMimeType(req.Header)
+	mimeType := m.getMimeType(req.Header)
 
 	hasPingHeaders := req.Header.Get("Ping-To") != "" || req.Header.Get("Ping-From") != ""
 	isPing := hasPingHeaders && mimeType == "text/ping"
@@ -98,7 +99,10 @@ func (m *ContentTypeModifier) ShouldMatchReq(req *http.Request) bool {
 }
 
 func (m *ContentTypeModifier) ShouldMatchRes(res *http.Response) bool {
-	mimeType := getMimeType(res.Header)
+	mimeType := m.getMimeType(res.Header)
+	if mimeType == "" {
+		return false
+	}
 
 	normalized, known := mapResponseContentTypeToModifier(mimeType)
 	if m.contentType == "other" {
@@ -150,7 +154,7 @@ func headerContains(h http.Header, name, value string) bool {
 	return false
 }
 
-func getMimeType(header http.Header) string {
+func (m *ContentTypeModifier) getMimeType(header http.Header) string {
 	contentType := header.Get("Content-Type")
 	if contentType == "" {
 		return ""

--- a/internal/networkrules/rulemodifiers/contenttype.go
+++ b/internal/networkrules/rulemodifiers/contenttype.go
@@ -60,18 +60,13 @@ func (m *ContentTypeModifier) Parse(modifier string) error {
 }
 
 func (m *ContentTypeModifier) ShouldMatchReq(req *http.Request) bool {
-	isPing := req.Header.Get("Ping-To") != "" ||
-		req.Header.Get("Ping-From") != "" ||
-		headerContains(req.Header, "Content-Type", "text/ping")
+	mimeType := m.getMimeType(req.Header)
+
+	hasPingHeaders := req.Header.Get("Ping-To") != "" || req.Header.Get("Ping-From") != ""
+	isPing := hasPingHeaders && mimeType == "text/ping"
 
 	if isPing {
-		if m.contentType == "other" {
-			return m.inverted
-		}
-		if m.contentType == "ping" {
-			return !m.inverted
-		}
-		return m.inverted
+		return (m.contentType == "ping") != m.inverted
 	}
 
 	if m.contentType == "ping" {
@@ -104,15 +99,7 @@ func (m *ContentTypeModifier) ShouldMatchReq(req *http.Request) bool {
 }
 
 func (m *ContentTypeModifier) ShouldMatchRes(res *http.Response) bool {
-	contentType := res.Header.Get("Content-Type")
-	if contentType == "" {
-		return false
-	}
-
-	// strip parameters like charset
-	mimeType, _, _ := strings.Cut(contentType, ";")
-	mimeType = strings.TrimSpace(mimeType)
-	mimeType = strings.ToLower(mimeType)
+	mimeType := m.getMimeType(res.Header)
 
 	normalized, known := mapResponseContentTypeToModifier(mimeType)
 	if m.contentType == "other" {
@@ -162,4 +149,18 @@ func headerContains(h http.Header, name, value string) bool {
 		}
 	}
 	return false
+}
+
+func (m *ContentTypeModifier) getMimeType(header http.Header) string {
+	contentType := header.Get("Content-Type")
+	if contentType == "" {
+		return ""
+	}
+
+	// strip parameters like charset
+	mimeType, _, _ := strings.Cut(contentType, ";")
+	mimeType = strings.TrimSpace(mimeType)
+	mimeType = strings.ToLower(mimeType)
+
+	return mimeType
 }

--- a/internal/networkrules/rulemodifiers/contenttype.go
+++ b/internal/networkrules/rulemodifiers/contenttype.go
@@ -36,6 +36,7 @@ var (
 	// contentTypeMap maps Content-Type MIME types to corresponding content type modifiers.
 	contentTypeMap = map[string]string{
 		"text/css":                      "stylesheet",
+		"text/ping":                     "ping",
 		"text/javascript":               "script",
 		"application/javascript":        "script",
 		"image":                         "image",
@@ -59,6 +60,24 @@ func (m *ContentTypeModifier) Parse(modifier string) error {
 }
 
 func (m *ContentTypeModifier) ShouldMatchReq(req *http.Request) bool {
+	isPing := req.Header.Get("Ping-To") != "" ||
+		req.Header.Get("Ping-From") != "" ||
+		headerContains(req.Header, "Content-Type", "text/ping")
+
+	if isPing {
+		if m.contentType == "other" {
+			return m.inverted
+		}
+		if m.contentType == "ping" {
+			return !m.inverted
+		}
+		return m.inverted
+	}
+
+	if m.contentType == "ping" {
+		return m.inverted
+	}
+
 	secFetchDest := req.Header.Get("Sec-Fetch-Dest")
 	if secFetchDest == "" {
 		if m.contentType == "websocket" {

--- a/internal/networkrules/rulemodifiers/contenttype_test.go
+++ b/internal/networkrules/rulemodifiers/contenttype_test.go
@@ -8,6 +8,19 @@ import (
 func TestContentTypeModifier_ShouldMatchReq(t *testing.T) {
 	t.Parallel()
 
+	t.Run("matches ping for ping modifier", func(t *testing.T) {
+		t.Parallel()
+
+		m := &ContentTypeModifier{contentType: "ping"}
+		req := &http.Request{
+			Header: http.Header{"Content-Type": []string{"text/ping"}, "Ping-To": []string{"http://example.com"}},
+		}
+
+		if !m.ShouldMatchReq(req) {
+			t.Fatal("expected to match ping")
+		}
+	})
+
 	t.Run("matches websocket for websocket modifier", func(t *testing.T) {
 		t.Parallel()
 
@@ -47,6 +60,17 @@ func TestContentTypeModifier_ShouldMatchReq(t *testing.T) {
 		}
 	})
 
+	t.Run("inverted ping with no headers matches", func(t *testing.T) {
+		t.Parallel()
+
+		m := &ContentTypeModifier{contentType: "ping", inverted: true}
+		req := &http.Request{}
+
+		if !m.ShouldMatchReq(req) {
+			t.Fatal("expected inverted with no header to match")
+		}
+	})
+
 	t.Run("inverted websocket with no headers matches", func(t *testing.T) {
 		t.Parallel()
 
@@ -69,6 +93,18 @@ func TestContentTypeModifier_ShouldMatchReq(t *testing.T) {
 		}
 	})
 
+	t.Run("inverted does not match ping modifier", func(t *testing.T) {
+		t.Parallel()
+
+		m := &ContentTypeModifier{contentType: "ping", inverted: true}
+		req := &http.Request{
+			Header: http.Header{"Content-Type": []string{"text/ping"}, "Ping-To": []string{"http://example.com"}},
+		}
+
+		if m.ShouldMatchReq(req) {
+			t.Fatal("expected inverted not to match ping")
+		}
+	})
 	t.Run("inverted does not match websocket modifier", func(t *testing.T) {
 		t.Parallel()
 
@@ -94,6 +130,46 @@ func TestContentTypeModifier_ShouldMatchReq(t *testing.T) {
 			t.Fatal("expected inverted with empty Sec-Fetch-Dest not to match")
 		}
 	})
+
+	t.Run("ping precedence over xmlhttprequest", func(t *testing.T) {
+		t.Parallel()
+
+		m := &ContentTypeModifier{contentType: "ping"}
+		req := &http.Request{
+			Header: http.Header{"Content-Type": []string{"text/ping"}, "Ping-To": []string{"http://example.com"}, "Sec-Fetch-Dest": []string{"xmlhttprequest"}},
+		}
+
+		if !m.ShouldMatchReq(req) {
+			t.Fatal("expected to match ping even with conflicting Sec-Fetch-Dest")
+		}
+	})
+
+	t.Run("ping not matched as other", func(t *testing.T) {
+		t.Parallel()
+
+		m := &ContentTypeModifier{contentType: "other"}
+		req := &http.Request{
+			Header: http.Header{"Content-Type": []string{"text/ping"}, "Ping-To": []string{"http://example.com"}},
+		}
+
+		if m.ShouldMatchReq(req) {
+			t.Fatal("expected ping not to match other")
+		}
+	})
+
+	t.Run("matches text/ping for ping modifier in response", func(t *testing.T) {
+		t.Parallel()
+
+		m := &ContentTypeModifier{contentType: "ping"}
+		res := &http.Response{
+			Header: http.Header{"Content-Type": []string{"text/ping; charset=utf-8"}},
+		}
+
+		if !m.ShouldMatchRes(res) {
+			t.Fatal("expected to match text/ping response")
+		}
+	})
+
 }
 
 func TestContentTypeModifier_ShouldMatchRes(t *testing.T) {

--- a/internal/networkrules/rulemodifiers/contenttype_test.go
+++ b/internal/networkrules/rulemodifiers/contenttype_test.go
@@ -136,7 +136,7 @@ func TestContentTypeModifier_ShouldMatchReq(t *testing.T) {
 
 		m := &ContentTypeModifier{contentType: "ping"}
 		req := &http.Request{
-			Header: http.Header{"Content-Type": []string{"text/ping"}, "Ping-To": []string{"http://example.com"}, "Sec-Fetch-Dest": []string{"xmlhttprequest"}},
+			Header: http.Header{"Content-Type": []string{"text/ping"}, "Ping-To": []string{"http://example.com"}, "Sec-Fetch-Dest": []string{"empty"}},
 		}
 
 		if !m.ShouldMatchReq(req) {

--- a/internal/networkrules/rulemodifiers/contenttype_test.go
+++ b/internal/networkrules/rulemodifiers/contenttype_test.go
@@ -157,19 +157,17 @@ func TestContentTypeModifier_ShouldMatchReq(t *testing.T) {
 		}
 	})
 
-	t.Run("matches text/ping for ping modifier in response", func(t *testing.T) {
+	t.Run("ping with charset matches", func(t *testing.T) {
 		t.Parallel()
 
 		m := &ContentTypeModifier{contentType: "ping"}
-		res := &http.Response{
-			Header: http.Header{"Content-Type": []string{"text/ping; charset=utf-8"}},
+		req := &http.Request{
+			Header: http.Header{"Content-Type": []string{"text/ping; charset=utf-8"}, "Ping-To": []string{"http://example.com"}},
 		}
-
-		if !m.ShouldMatchRes(res) {
-			t.Fatal("expected to match text/ping response")
+		if !m.ShouldMatchReq(req) {
+			t.Fatal("expected ping with charset and ping headers to match")
 		}
 	})
-
 }
 
 func TestContentTypeModifier_ShouldMatchRes(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?
This PR implements the $ping content type modifier for hyperlink auditing.

- Added ping to ContentTypeModifier and registered it in rule.go.

- Added early matching in ShouldMatchReq for ping headers. This avoids falling back to xmlhttprequest by mistake when Sec-Fetch-Dest: empty is present.

- Used `(Ping-To || Ping-From) && Content-Type` to check Ping-To, Ping-From, and Content-Type: text/ping. This is needed to catch pings even if the browser hides some headers because of privacy policies.

- Made sure ~ping (inversion) works properly.

### How did you verify your code works?
I wrote tests in contenttype_test.go. I added tests to check the standard matching with the headers, the inversion (~ping), the precedence over xmlhttprequest, and the response matching.

### What are the relevant issues?

Closes #719  