### PR TITLE
feat: support noop modifiers

### DIFF
--- a/internal/networkrules/rule/rule.go
+++ b/internal/networkrules/rule/rule.go
@@ -43,6 +43,11 @@ func (rm *Rule) ParseModifiers(modifiers []string) error {
 			return errors.New("empty modifier")
 		}
 
+		// Noop modifier is ignored
+		if isNoopModifier(m) {
+			continue
+		}
+
 		name, hasValue := cutModifierName(m)
 
 		var modifier rulemodifiers.Modifier
@@ -122,6 +127,19 @@ func (rm *Rule) ParseModifiers(modifiers []string) error {
 	}
 
 	return nil
+}
+
+// isNoopModifier returns true if modifier is one or more underscores.
+func isNoopModifier(modifier string) bool {
+	if modifier == "" {
+		return false
+	}
+	for i := 0; i < len(modifier); i++ {
+		if modifier[i] != '_' {
+			return false
+		}
+	}
+	return true
 }
 
 func cutModifierName(modifier string) (name string, hasValue bool) {

--- a/internal/networkrules/rule/rule.go
+++ b/internal/networkrules/rule/rule.go
@@ -131,9 +131,6 @@ func (rm *Rule) ParseModifiers(modifiers []string) error {
 
 // isNoopModifier returns true if modifier is one or more underscores.
 func isNoopModifier(modifier string) bool {
-	if modifier == "" {
-		return false
-	}
 	for i := 0; i < len(modifier); i++ {
 		if modifier[i] != '_' {
 			return false

--- a/internal/networkrules/rule/rule_test.go
+++ b/internal/networkrules/rule/rule_test.go
@@ -100,6 +100,63 @@ func TestParseModifiers(t *testing.T) {
 		)
 	})
 
+	t.Run("noop modifiers are ignored", func(t *testing.T) {
+		t.Parallel()
+
+		for _, modifier := range []string{"_", "__", "___", "____"} {
+			t.Run(modifier, func(t *testing.T) {
+				t.Parallel()
+
+				var r Rule
+				if err := r.ParseModifiers([]string{modifier}); err != nil {
+					t.Fatalf("ParseModifiers(%q) = %v, want nil", modifier, err)
+				}
+
+				assertRuleBuckets(t, &r, false, nil, nil, nil, nil)
+			})
+		}
+	})
+
+	t.Run("noop modifiers do not affect other modifiers", func(t *testing.T) {
+		t.Parallel()
+
+		var r Rule
+		if err := r.ParseModifiers([]string{"script", "_", "domain=example.com", "__"}); err != nil {
+			t.Fatalf("ParseModifiers() = %v, want nil", err)
+		}
+
+		assertRuleBuckets(t, &r, false,
+			[]string{"*rulemodifiers.DomainModifier"},
+			[]string{"*rulemodifiers.ContentTypeModifier"},
+			nil,
+			nil,
+		)
+	})
+
+	t.Run("rejects noop-like modifiers with non-underscore characters", func(t *testing.T) {
+		t.Parallel()
+
+		for _, modifier := range []string{
+			"_abc",      // letters after underscore
+			"abc_",      // letters before underscore
+			"___=value", // noop with a value
+			"_=_",       // underscore with a value
+		} {
+			t.Run(modifier, func(t *testing.T) {
+				t.Parallel()
+
+				var r Rule
+				err := r.ParseModifiers([]string{modifier})
+				if err == nil {
+					t.Fatalf("ParseModifiers(%q) = nil, want unknown modifier error", modifier)
+				}
+				if !strings.Contains(err.Error(), "unknown modifier") {
+					t.Fatalf("ParseModifiers(%q) error = %q, want unknown modifier", modifier, err)
+				}
+			})
+		}
+	})
+
 	t.Run("rejects prefix collisions", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
### What does this PR do?

This PR adds support for noop modifiers resolving issue #715

### How did you verify your code works?

I added tests in rule_test.go

- noop modifiers are ignored: Checks that _, __, ___ parse without errors.
- noop modifiers do not affect other modifiers: Checks that 'noop' with other modifiers dont break parsing
- rejects noop-like modifiers with non-underscore characters: invalid modifiers containing underscores (like `_abc`, `___=value`) are rejected with an 'unknown modifier' error.

### What are the relevant issues?

Closes #715
