### PR TITLE
Feat: implement important modifier

### DIFF
--- a/internal/networkrules/exceptionrule/exceptionrule.go
+++ b/internal/networkrules/exceptionrule/exceptionrule.go
@@ -11,6 +11,10 @@ type ExceptionRule struct {
 }
 
 func (er *ExceptionRule) Cancels(r *rule.Rule) bool {
+	if r.Important && !er.Important {
+		return false
+	}
+
 	if er.Document && !r.Document {
 		return false
 	}

--- a/internal/networkrules/exceptionrule/exceptionrule_test.go
+++ b/internal/networkrules/exceptionrule/exceptionrule_test.go
@@ -80,4 +80,37 @@ func TestExceptionRule(t *testing.T) {
 			t.Errorf("'%s'.Cancels('%s') = %t, want %t", er.RawRule, r.RawRule, got, want)
 		}
 	})
+
+	t.Run("important exception should cancel important block", func(t *testing.T) {
+		t.Parallel()
+
+		er := &ExceptionRule{Rule: rule.Rule{Important: true}}
+		r := &rule.Rule{Important: true}
+
+		if !er.Cancels(r) {
+			t.Errorf("Important exception rule should cancel important block rule")
+		}
+	})
+
+	t.Run("normal exception should not cancel important block", func(t *testing.T) {
+		t.Parallel()
+
+		er := &ExceptionRule{Rule: rule.Rule{Important: false}}
+		r := &rule.Rule{Important: true}
+
+		if er.Cancels(r) {
+			t.Errorf("Normal exception rule should NOT cancel important block rule")
+		}
+	})
+
+	t.Run("important exception should cancel normal block", func(t *testing.T) {
+		t.Parallel()
+
+		er := &ExceptionRule{Rule: rule.Rule{Important: true}}
+		r := &rule.Rule{Important: false}
+
+		if !er.Cancels(r) {
+			t.Errorf("Important exception rule should cancel normal block rule")
+		}
+	})
 }

--- a/internal/networkrules/rule/rule.go
+++ b/internal/networkrules/rule/rule.go
@@ -25,6 +25,8 @@ type Rule struct {
 
 	// Document shows if rule has Document modifier.
 	Document bool
+	// Important shows if rule has Important modifier.
+	Important bool
 }
 
 // TODO: The split between And and Or modifiers is somewhat convoluted and exists only to support ContentType.
@@ -53,6 +55,9 @@ func (rm *Rule) ParseModifiers(modifiers []string) error {
 			switch name {
 			case "document", "doc":
 				rm.Document = true
+				continue
+			case "important":
+				rm.Important = true
 				continue
 			case "xmlhttprequest",
 				"xhr",

--- a/internal/networkrules/rule/rule.go
+++ b/internal/networkrules/rule/rule.go
@@ -64,6 +64,7 @@ func (rm *Rule) ParseModifiers(modifiers []string) error {
 				"stylesheet",
 				"media",
 				"websocket",
+				"ping",
 				"other":
 				modifier = &rulemodifiers.ContentTypeModifier{}
 				isOr = true

--- a/internal/networkrules/rule/rule_test.go
+++ b/internal/networkrules/rule/rule_test.go
@@ -17,7 +17,18 @@ func TestParseModifiers(t *testing.T) {
 			t.Fatalf("ParseModifiers(nil) = %v, want nil", err)
 		}
 
-		assertRuleBuckets(t, &r, false, nil, nil, nil, nil)
+		assertRuleBuckets(t, &r, false, false, nil, nil, nil, nil)
+	})
+
+	t.Run("important modifier sets important flag only", func(t *testing.T) {
+		t.Parallel()
+
+		var r Rule
+		if err := r.ParseModifiers([]string{"important"}); err != nil {
+			t.Fatalf("ParseModifiers(%q) = %v, want nil", "important", err)
+		}
+
+		assertRuleBuckets(t, &r, true, false, nil, nil, nil, nil)
 	})
 
 	t.Run("document modifiers set document flag only", func(t *testing.T) {
@@ -32,7 +43,7 @@ func TestParseModifiers(t *testing.T) {
 					t.Fatalf("ParseModifiers(%q) = %v, want nil", modifier, err)
 				}
 
-				assertRuleBuckets(t, &r, true, nil, nil, nil, nil)
+				assertRuleBuckets(t, &r, false, true, nil, nil, nil, nil)
 			})
 		}
 	})
@@ -68,7 +79,7 @@ func TestParseModifiers(t *testing.T) {
 			t.Fatalf("ParseModifiers() = %v, want nil", err)
 		}
 
-		assertRuleBuckets(t, &r, false,
+		assertRuleBuckets(t, &r, false, false,
 			[]string{
 				"*rulemodifiers.DomainModifier",
 				"*rulemodifiers.MethodModifier",
@@ -151,9 +162,12 @@ func TestParseModifiers(t *testing.T) {
 	})
 }
 
-func assertRuleBuckets(t *testing.T, r *Rule, wantDocument bool, wantAnd, wantOr, wantQuery, wantActions []string) {
+func assertRuleBuckets(t *testing.T, r *Rule, wantImportant, wantDocument bool, wantAnd, wantOr, wantQuery, wantActions []string) {
 	t.Helper()
 
+	if r.Important != wantImportant {
+		t.Errorf("Important = %v, want %v", r.Important, wantImportant)
+	}
 	if r.Document != wantDocument {
 		t.Errorf("Document = %v, want %v", r.Document, wantDocument)
 	}

--- a/internal/networkrules/rulemodifiers/contenttype.go
+++ b/internal/networkrules/rulemodifiers/contenttype.go
@@ -36,7 +36,6 @@ var (
 	// contentTypeMap maps Content-Type MIME types to corresponding content type modifiers.
 	contentTypeMap = map[string]string{
 		"text/css":                      "stylesheet",
-		"text/ping":                     "ping",
 		"text/javascript":               "script",
 		"application/javascript":        "script",
 		"image":                         "image",
@@ -60,7 +59,7 @@ func (m *ContentTypeModifier) Parse(modifier string) error {
 }
 
 func (m *ContentTypeModifier) ShouldMatchReq(req *http.Request) bool {
-	mimeType := m.getMimeType(req.Header)
+	mimeType := getMimeType(req.Header)
 
 	hasPingHeaders := req.Header.Get("Ping-To") != "" || req.Header.Get("Ping-From") != ""
 	isPing := hasPingHeaders && mimeType == "text/ping"
@@ -99,7 +98,7 @@ func (m *ContentTypeModifier) ShouldMatchReq(req *http.Request) bool {
 }
 
 func (m *ContentTypeModifier) ShouldMatchRes(res *http.Response) bool {
-	mimeType := m.getMimeType(res.Header)
+	mimeType := getMimeType(res.Header)
 
 	normalized, known := mapResponseContentTypeToModifier(mimeType)
 	if m.contentType == "other" {
@@ -151,7 +150,7 @@ func headerContains(h http.Header, name, value string) bool {
 	return false
 }
 
-func (m *ContentTypeModifier) getMimeType(header http.Header) string {
+func getMimeType(header http.Header) string {
 	contentType := header.Get("Content-Type")
 	if contentType == "" {
 		return ""

--- a/internal/networkrules/rulemodifiers/contenttype.go
+++ b/internal/networkrules/rulemodifiers/contenttype.go
@@ -36,6 +36,7 @@ var (
 	// contentTypeMap maps Content-Type MIME types to corresponding content type modifiers.
 	contentTypeMap = map[string]string{
 		"text/css":                      "stylesheet",
+		"text/ping":                     "ping",
 		"text/javascript":               "script",
 		"application/javascript":        "script",
 		"image":                         "image",
@@ -59,7 +60,7 @@ func (m *ContentTypeModifier) Parse(modifier string) error {
 }
 
 func (m *ContentTypeModifier) ShouldMatchReq(req *http.Request) bool {
-	mimeType := getMimeType(req.Header)
+	mimeType := m.getMimeType(req.Header)
 
 	hasPingHeaders := req.Header.Get("Ping-To") != "" || req.Header.Get("Ping-From") != ""
 	isPing := hasPingHeaders && mimeType == "text/ping"
@@ -98,7 +99,10 @@ func (m *ContentTypeModifier) ShouldMatchReq(req *http.Request) bool {
 }
 
 func (m *ContentTypeModifier) ShouldMatchRes(res *http.Response) bool {
-	mimeType := getMimeType(res.Header)
+	mimeType := m.getMimeType(res.Header)
+	if mimeType == "" {
+		return false
+	}
 
 	normalized, known := mapResponseContentTypeToModifier(mimeType)
 	if m.contentType == "other" {
@@ -150,7 +154,7 @@ func headerContains(h http.Header, name, value string) bool {
 	return false
 }
 
-func getMimeType(header http.Header) string {
+func (m *ContentTypeModifier) getMimeType(header http.Header) string {
 	contentType := header.Get("Content-Type")
 	if contentType == "" {
 		return ""

--- a/internal/networkrules/rulemodifiers/contenttype.go
+++ b/internal/networkrules/rulemodifiers/contenttype.go
@@ -60,18 +60,13 @@ func (m *ContentTypeModifier) Parse(modifier string) error {
 }
 
 func (m *ContentTypeModifier) ShouldMatchReq(req *http.Request) bool {
-	isPing := req.Header.Get("Ping-To") != "" ||
-		req.Header.Get("Ping-From") != "" ||
-		headerContains(req.Header, "Content-Type", "text/ping")
+	mimeType := m.getMimeType(req.Header)
+
+	hasPingHeaders := req.Header.Get("Ping-To") != "" || req.Header.Get("Ping-From") != ""
+	isPing := hasPingHeaders && mimeType == "text/ping"
 
 	if isPing {
-		if m.contentType == "other" {
-			return m.inverted
-		}
-		if m.contentType == "ping" {
-			return !m.inverted
-		}
-		return m.inverted
+		return (m.contentType == "ping") != m.inverted
 	}
 
 	if m.contentType == "ping" {
@@ -104,15 +99,7 @@ func (m *ContentTypeModifier) ShouldMatchReq(req *http.Request) bool {
 }
 
 func (m *ContentTypeModifier) ShouldMatchRes(res *http.Response) bool {
-	contentType := res.Header.Get("Content-Type")
-	if contentType == "" {
-		return false
-	}
-
-	// strip parameters like charset
-	mimeType, _, _ := strings.Cut(contentType, ";")
-	mimeType = strings.TrimSpace(mimeType)
-	mimeType = strings.ToLower(mimeType)
+	mimeType := m.getMimeType(res.Header)
 
 	normalized, known := mapResponseContentTypeToModifier(mimeType)
 	if m.contentType == "other" {
@@ -162,4 +149,18 @@ func headerContains(h http.Header, name, value string) bool {
 		}
 	}
 	return false
+}
+
+func (m *ContentTypeModifier) getMimeType(header http.Header) string {
+	contentType := header.Get("Content-Type")
+	if contentType == "" {
+		return ""
+	}
+
+	// strip parameters like charset
+	mimeType, _, _ := strings.Cut(contentType, ";")
+	mimeType = strings.TrimSpace(mimeType)
+	mimeType = strings.ToLower(mimeType)
+
+	return mimeType
 }

--- a/internal/networkrules/rulemodifiers/contenttype.go
+++ b/internal/networkrules/rulemodifiers/contenttype.go
@@ -36,6 +36,7 @@ var (
 	// contentTypeMap maps Content-Type MIME types to corresponding content type modifiers.
 	contentTypeMap = map[string]string{
 		"text/css":                      "stylesheet",
+		"text/ping":                     "ping",
 		"text/javascript":               "script",
 		"application/javascript":        "script",
 		"image":                         "image",
@@ -59,6 +60,24 @@ func (m *ContentTypeModifier) Parse(modifier string) error {
 }
 
 func (m *ContentTypeModifier) ShouldMatchReq(req *http.Request) bool {
+	isPing := req.Header.Get("Ping-To") != "" ||
+		req.Header.Get("Ping-From") != "" ||
+		headerContains(req.Header, "Content-Type", "text/ping")
+
+	if isPing {
+		if m.contentType == "other" {
+			return m.inverted
+		}
+		if m.contentType == "ping" {
+			return !m.inverted
+		}
+		return m.inverted
+	}
+
+	if m.contentType == "ping" {
+		return m.inverted
+	}
+
 	secFetchDest := req.Header.Get("Sec-Fetch-Dest")
 	if secFetchDest == "" {
 		if m.contentType == "websocket" {

--- a/internal/networkrules/rulemodifiers/contenttype_test.go
+++ b/internal/networkrules/rulemodifiers/contenttype_test.go
@@ -8,6 +8,19 @@ import (
 func TestContentTypeModifier_ShouldMatchReq(t *testing.T) {
 	t.Parallel()
 
+	t.Run("matches ping for ping modifier", func(t *testing.T) {
+		t.Parallel()
+
+		m := &ContentTypeModifier{contentType: "ping"}
+		req := &http.Request{
+			Header: http.Header{"Content-Type": []string{"text/ping"}, "Ping-To": []string{"http://example.com"}},
+		}
+
+		if !m.ShouldMatchReq(req) {
+			t.Fatal("expected to match ping")
+		}
+	})
+
 	t.Run("matches websocket for websocket modifier", func(t *testing.T) {
 		t.Parallel()
 
@@ -47,6 +60,17 @@ func TestContentTypeModifier_ShouldMatchReq(t *testing.T) {
 		}
 	})
 
+	t.Run("inverted ping with no headers matches", func(t *testing.T) {
+		t.Parallel()
+
+		m := &ContentTypeModifier{contentType: "ping", inverted: true}
+		req := &http.Request{}
+
+		if !m.ShouldMatchReq(req) {
+			t.Fatal("expected inverted with no header to match")
+		}
+	})
+
 	t.Run("inverted websocket with no headers matches", func(t *testing.T) {
 		t.Parallel()
 
@@ -69,6 +93,18 @@ func TestContentTypeModifier_ShouldMatchReq(t *testing.T) {
 		}
 	})
 
+	t.Run("inverted does not match ping modifier", func(t *testing.T) {
+		t.Parallel()
+
+		m := &ContentTypeModifier{contentType: "ping", inverted: true}
+		req := &http.Request{
+			Header: http.Header{"Content-Type": []string{"text/ping"}, "Ping-To": []string{"http://example.com"}},
+		}
+
+		if m.ShouldMatchReq(req) {
+			t.Fatal("expected inverted not to match ping")
+		}
+	})
 	t.Run("inverted does not match websocket modifier", func(t *testing.T) {
 		t.Parallel()
 
@@ -94,6 +130,46 @@ func TestContentTypeModifier_ShouldMatchReq(t *testing.T) {
 			t.Fatal("expected inverted with empty Sec-Fetch-Dest not to match")
 		}
 	})
+
+	t.Run("ping precedence over xmlhttprequest", func(t *testing.T) {
+		t.Parallel()
+
+		m := &ContentTypeModifier{contentType: "ping"}
+		req := &http.Request{
+			Header: http.Header{"Content-Type": []string{"text/ping"}, "Ping-To": []string{"http://example.com"}, "Sec-Fetch-Dest": []string{"xmlhttprequest"}},
+		}
+
+		if !m.ShouldMatchReq(req) {
+			t.Fatal("expected to match ping even with conflicting Sec-Fetch-Dest")
+		}
+	})
+
+	t.Run("ping not matched as other", func(t *testing.T) {
+		t.Parallel()
+
+		m := &ContentTypeModifier{contentType: "other"}
+		req := &http.Request{
+			Header: http.Header{"Content-Type": []string{"text/ping"}, "Ping-To": []string{"http://example.com"}},
+		}
+
+		if m.ShouldMatchReq(req) {
+			t.Fatal("expected ping not to match other")
+		}
+	})
+
+	t.Run("matches text/ping for ping modifier in response", func(t *testing.T) {
+		t.Parallel()
+
+		m := &ContentTypeModifier{contentType: "ping"}
+		res := &http.Response{
+			Header: http.Header{"Content-Type": []string{"text/ping; charset=utf-8"}},
+		}
+
+		if !m.ShouldMatchRes(res) {
+			t.Fatal("expected to match text/ping response")
+		}
+	})
+
 }
 
 func TestContentTypeModifier_ShouldMatchRes(t *testing.T) {

--- a/internal/networkrules/rulemodifiers/contenttype_test.go
+++ b/internal/networkrules/rulemodifiers/contenttype_test.go
@@ -136,7 +136,7 @@ func TestContentTypeModifier_ShouldMatchReq(t *testing.T) {
 
 		m := &ContentTypeModifier{contentType: "ping"}
 		req := &http.Request{
-			Header: http.Header{"Content-Type": []string{"text/ping"}, "Ping-To": []string{"http://example.com"}, "Sec-Fetch-Dest": []string{"xmlhttprequest"}},
+			Header: http.Header{"Content-Type": []string{"text/ping"}, "Ping-To": []string{"http://example.com"}, "Sec-Fetch-Dest": []string{"empty"}},
 		}
 
 		if !m.ShouldMatchReq(req) {

--- a/internal/networkrules/rulemodifiers/contenttype_test.go
+++ b/internal/networkrules/rulemodifiers/contenttype_test.go
@@ -157,19 +157,17 @@ func TestContentTypeModifier_ShouldMatchReq(t *testing.T) {
 		}
 	})
 
-	t.Run("matches text/ping for ping modifier in response", func(t *testing.T) {
+	t.Run("ping with charset matches", func(t *testing.T) {
 		t.Parallel()
 
 		m := &ContentTypeModifier{contentType: "ping"}
-		res := &http.Response{
-			Header: http.Header{"Content-Type": []string{"text/ping; charset=utf-8"}},
+		req := &http.Request{
+			Header: http.Header{"Content-Type": []string{"text/ping; charset=utf-8"}, "Ping-To": []string{"http://example.com"}},
 		}
-
-		if !m.ShouldMatchRes(res) {
-			t.Fatal("expected to match text/ping response")
+		if !m.ShouldMatchReq(req) {
+			t.Fatal("expected ping with charset and ping headers to match")
 		}
 	})
-
 }
 
 func TestContentTypeModifier_ShouldMatchRes(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

This PR implements the `$important` modifier for network rules, ensuring compliance with standard ad-blocking syntax (as supported by uBlock Origin and AdGuard).

- Added `Important` flag to the Rule struct.
- Updated `ParseModifiers` to recognize important as a valid flag modifier.
- Updated `ExceptionRule.Cancels` to force the new precedence logic:

### How did you verify your code works?

- `rule_test.go`: Added a new test case to ensure the Important flag is correctly parsed and set during rule initialization. Updated the `assertRuleBuckets` helper and existing tests to maintain consistency.
- `exceptionrule_test.go`: Added specific test scenarios to validate the precedence logic:
    - Verified that an important exception rule correctly cancels both normal and important block rules.
    - Verified that a normal exception rule fails to cancel an important block rule.

### What are the relevant issues?

Closes #731 
