### PR TITLE
feat: implement important modifier

### DIFF
--- a/internal/networkrules/exceptionrule/exceptionrule.go
+++ b/internal/networkrules/exceptionrule/exceptionrule.go
@@ -11,6 +11,10 @@ type ExceptionRule struct {
 }
 
 func (er *ExceptionRule) Cancels(r *rule.Rule) bool {
+	if r.Important && !er.Important {
+		return false
+	}
+
 	if er.Document && !r.Document {
 		return false
 	}

--- a/internal/networkrules/exceptionrule/exceptionrule_test.go
+++ b/internal/networkrules/exceptionrule/exceptionrule_test.go
@@ -81,36 +81,73 @@ func TestExceptionRule(t *testing.T) {
 		}
 	})
 
-	t.Run("important exception should cancel important block", func(t *testing.T) {
+	t.Run("'@@||page$important' should cancel '||page$important'", func(t *testing.T) {
 		t.Parallel()
 
-		er := &ExceptionRule{Rule: rule.Rule{Important: true}}
-		r := &rule.Rule{Important: true}
+		filterName := "test"
 
-		if !er.Cancels(r) {
-			t.Errorf("Important exception rule should cancel important block rule")
+		er := &ExceptionRule{
+			Rule: rule.Rule{
+				RawRule:    "@@||example.com$important",
+				FilterName: &filterName,
+			},
+		}
+		r := &rule.Rule{
+			RawRule:    "||example.com$important",
+			FilterName: &filterName,
+		}
+		r.ParseModifiers([]string{"important"})
+		er.ParseModifiers([]string{"important"})
+
+		want := true
+		if got := er.Cancels(r); got != want {
+			t.Errorf("'%s'.Cancels('%s') = %t, want %t", er.RawRule, r.RawRule, got, want)
 		}
 	})
 
-	t.Run("normal exception should not cancel important block", func(t *testing.T) {
+	t.Run("'@@||page' should not cancel '||page$important'", func(t *testing.T) {
 		t.Parallel()
 
-		er := &ExceptionRule{Rule: rule.Rule{Important: false}}
-		r := &rule.Rule{Important: true}
+		filterName := "test"
 
-		if er.Cancels(r) {
-			t.Errorf("Normal exception rule should NOT cancel important block rule")
+		er := &ExceptionRule{
+			Rule: rule.Rule{
+				RawRule:    "@@||example.com",
+				FilterName: &filterName,
+			},
+		}
+		r := &rule.Rule{
+			RawRule:    "||example.com$important",
+			FilterName: &filterName,
+		}
+		r.ParseModifiers([]string{"important"})
+
+		want := false
+		if got := er.Cancels(r); got != want {
+			t.Errorf("'%s'.Cancels('%s') = %t, want %t", er.RawRule, r.RawRule, got, want)
 		}
 	})
 
-	t.Run("important exception should cancel normal block", func(t *testing.T) {
+	t.Run("'@@||page$important' should cancel '||page'", func(t *testing.T) {
 		t.Parallel()
 
-		er := &ExceptionRule{Rule: rule.Rule{Important: true}}
-		r := &rule.Rule{Important: false}
+		filterName := "test"
 
-		if !er.Cancels(r) {
-			t.Errorf("Important exception rule should cancel normal block rule")
+		er := &ExceptionRule{
+			Rule: rule.Rule{
+				RawRule:    "@@||example.com$important",
+				FilterName: &filterName,
+			},
+		}
+		r := &rule.Rule{
+			RawRule:    "||example.com",
+			FilterName: &filterName,
+		}
+		er.ParseModifiers([]string{"important"})
+
+		want := true
+		if got := er.Cancels(r); got != want {
+			t.Errorf("'%s'.Cancels('%s') = %t, want %t", er.RawRule, r.RawRule, got, want)
 		}
 	})
 }

--- a/internal/networkrules/exceptionrule/exceptionrule_test.go
+++ b/internal/networkrules/exceptionrule/exceptionrule_test.go
@@ -80,4 +80,37 @@ func TestExceptionRule(t *testing.T) {
 			t.Errorf("'%s'.Cancels('%s') = %t, want %t", er.RawRule, r.RawRule, got, want)
 		}
 	})
+
+	t.Run("important exception should cancel important block", func(t *testing.T) {
+		t.Parallel()
+
+		er := &ExceptionRule{Rule: rule.Rule{Important: true}}
+		r := &rule.Rule{Important: true}
+
+		if !er.Cancels(r) {
+			t.Errorf("Important exception rule should cancel important block rule")
+		}
+	})
+
+	t.Run("normal exception should not cancel important block", func(t *testing.T) {
+		t.Parallel()
+
+		er := &ExceptionRule{Rule: rule.Rule{Important: false}}
+		r := &rule.Rule{Important: true}
+
+		if er.Cancels(r) {
+			t.Errorf("Normal exception rule should NOT cancel important block rule")
+		}
+	})
+
+	t.Run("important exception should cancel normal block", func(t *testing.T) {
+		t.Parallel()
+
+		er := &ExceptionRule{Rule: rule.Rule{Important: true}}
+		r := &rule.Rule{Important: false}
+
+		if !er.Cancels(r) {
+			t.Errorf("Important exception rule should cancel normal block rule")
+		}
+	})
 }

--- a/internal/networkrules/networkrules_test.go
+++ b/internal/networkrules/networkrules_test.go
@@ -345,6 +345,40 @@ func TestExceptionRules(t *testing.T) {
 			t.Fatal("expected response header to be preserved")
 		}
 	})
+
+	t.Run("normal exception does not cancel important primary", func(t *testing.T) {
+		t.Parallel()
+
+		nr := New()
+		if _, err := nr.ParseRule(`||example.com^$important`, nil); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := nr.ParseRule(`@@||example.com^`, nil); err != nil {
+			t.Fatal(err)
+		}
+
+		_, shouldBlock, _ := nr.ModifyReq(newTestRequest(t, "https://example.com/", nil))
+		if !shouldBlock {
+			t.Fatal("expected normal exception NOT to cancel important primary rule")
+		}
+	})
+
+	t.Run("important exception cancels important primary", func(t *testing.T) {
+		t.Parallel()
+
+		nr := New()
+		if _, err := nr.ParseRule(`||example.com^$important`, nil); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := nr.ParseRule(`@@||example.com^$important`, nil); err != nil {
+			t.Fatal(err)
+		}
+
+		_, shouldBlock, _ := nr.ModifyReq(newTestRequest(t, "https://example.com/", nil))
+		if shouldBlock {
+			t.Fatal("expected important exception to cancel important primary rule")
+		}
+	})
 }
 
 func newTestRequest(t *testing.T, rawURL string, headers http.Header) *http.Request {

--- a/internal/networkrules/rule/rule.go
+++ b/internal/networkrules/rule/rule.go
@@ -25,6 +25,8 @@ type Rule struct {
 
 	// Document shows if rule has Document modifier.
 	Document bool
+	// Important shows if rule has Important modifier.
+	Important bool
 }
 
 // TODO: The split between And and Or modifiers is somewhat convoluted and exists only to support ContentType.
@@ -58,6 +60,9 @@ func (rm *Rule) ParseModifiers(modifiers []string) error {
 			switch name {
 			case "document", "doc":
 				rm.Document = true
+				continue
+			case "important":
+				rm.Important = true
 				continue
 			case "xmlhttprequest",
 				"xhr",

--- a/internal/networkrules/rule/rule_test.go
+++ b/internal/networkrules/rule/rule_test.go
@@ -17,7 +17,18 @@ func TestParseModifiers(t *testing.T) {
 			t.Fatalf("ParseModifiers(nil) = %v, want nil", err)
 		}
 
-		assertRuleBuckets(t, &r, false, nil, nil, nil, nil)
+		assertRuleBuckets(t, &r, false, false, nil, nil, nil, nil)
+	})
+
+	t.Run("important modifier sets important flag only", func(t *testing.T) {
+		t.Parallel()
+
+		var r Rule
+		if err := r.ParseModifiers([]string{"important"}); err != nil {
+			t.Fatalf("ParseModifiers(%q) = %v, want nil", "important", err)
+		}
+
+		assertRuleBuckets(t, &r, true, false, nil, nil, nil, nil)
 	})
 
 	t.Run("document modifiers set document flag only", func(t *testing.T) {
@@ -32,7 +43,7 @@ func TestParseModifiers(t *testing.T) {
 					t.Fatalf("ParseModifiers(%q) = %v, want nil", modifier, err)
 				}
 
-				assertRuleBuckets(t, &r, true, nil, nil, nil, nil)
+				assertRuleBuckets(t, &r, false, true, nil, nil, nil, nil)
 			})
 		}
 	})
@@ -68,7 +79,7 @@ func TestParseModifiers(t *testing.T) {
 			t.Fatalf("ParseModifiers() = %v, want nil", err)
 		}
 
-		assertRuleBuckets(t, &r, false,
+		assertRuleBuckets(t, &r, false, false,
 			[]string{
 				"*rulemodifiers.DomainModifier",
 				"*rulemodifiers.MethodModifier",
@@ -208,9 +219,12 @@ func TestParseModifiers(t *testing.T) {
 	})
 }
 
-func assertRuleBuckets(t *testing.T, r *Rule, wantDocument bool, wantAnd, wantOr, wantQuery, wantActions []string) {
+func assertRuleBuckets(t *testing.T, r *Rule, wantImportant, wantDocument bool, wantAnd, wantOr, wantQuery, wantActions []string) {
 	t.Helper()
 
+	if r.Important != wantImportant {
+		t.Errorf("Important = %v, want %v", r.Important, wantImportant)
+	}
 	if r.Document != wantDocument {
 		t.Errorf("Document = %v, want %v", r.Document, wantDocument)
 	}

--- a/internal/networkrules/rule/rule_test.go
+++ b/internal/networkrules/rule/rule_test.go
@@ -123,7 +123,7 @@ func TestParseModifiers(t *testing.T) {
 					t.Fatalf("ParseModifiers(%q) = %v, want nil", modifier, err)
 				}
 
-				assertRuleBuckets(t, &r, false, nil, nil, nil, nil)
+				assertRuleBuckets(t, &r, false, false, nil, nil, nil, nil)
 			})
 		}
 	})
@@ -136,7 +136,7 @@ func TestParseModifiers(t *testing.T) {
 			t.Fatalf("ParseModifiers() = %v, want nil", err)
 		}
 
-		assertRuleBuckets(t, &r, false,
+		assertRuleBuckets(t, &r, false, false,
 			[]string{"*rulemodifiers.DomainModifier"},
 			[]string{"*rulemodifiers.ContentTypeModifier"},
 			nil,


### PR DESCRIPTION
### What does this PR do?

This PR implements the `$important` modifier for network rules, ensuring compliance with standard ad-blocking syntax (as supported by uBlock Origin and AdGuard).

- Added `Important` flag to the Rule struct.
- Updated `ParseModifiers` to recognize important as a valid flag modifier.
- Updated `ExceptionRule.Cancels` to force the new precedence logic:

### How did you verify your code works?

- `rule_test.go`: Added a new test case to ensure the Important flag is correctly parsed and set during rule initialization. Updated the `assertRuleBuckets` helper and existing tests to maintain consistency.
- `exceptionrule_test.go`: Added specific test scenarios to validate the precedence logic:
    - Verified that an important exception rule correctly cancels both normal and important block rules.
    - Verified that a normal exception rule fails to cancel an important block rule.

### What are the relevant issues?

Closes #731 
