### PR TITLE
Elevate networksetup commands if needed

### DIFF
--- a/internal/sysproxy/system_darwin.go
+++ b/internal/sysproxy/system_darwin.go
@@ -46,6 +46,15 @@ func setSystemProxy(pacURL string) error {
 
 	for _, args := range cmds {
 		if out, err := exec.Command(args[0], args[1:]...).CombinedOutput(); err != nil { // #nosec G204 -- command input comes from trusted sources
+			if isAdminPrivilegesError(out) {
+				// The pre-check reads system.preferences.network, but since macOS 26 networksetup
+				// denies standard users regardless of that right (see discussion #751).
+				// Retry the whole batch elevated; re-running already-succeeded commands is harmless.
+				if out, err := runElevated(cmds); err != nil {
+					return fmt.Errorf("set system proxy with elevation: %v (%q)", err, out)
+				}
+				return nil
+			}
 			return fmt.Errorf("%s: %v (%q)", strings.Join(args, " "), err, out)
 		}
 	}
@@ -71,6 +80,16 @@ func unsetSystemProxy() error {
 	} else {
 		for _, args := range cmds {
 			if out, err := exec.Command(args[0], args[1:]...).CombinedOutput(); err != nil { // #nosec G204 -- command input comes from trusted sources
+				if isAdminPrivilegesError(out) {
+					// See the equivalent fallback in setSystemProxy. The elevated batch retries
+					// every command, superseding any per-command errors collected so far.
+					if out, err := runElevated(cmds); err != nil {
+						finalErr = fmt.Errorf("unset system proxy with elevation: %v (%q)", err, out)
+					} else {
+						finalErr = nil
+					}
+					break
+				}
 				finalErr = multierror.Append(finalErr, fmt.Errorf("%s: %v (%q)", strings.Join(args, " "), err, out))
 			}
 		}
@@ -95,6 +114,14 @@ func requiresAdminPrivileges() bool {
 	}
 	// When "Require an administrator password to access system-wide settings" is enabled, "shared" is false.
 	return !entry.Shared
+}
+
+// isAdminPrivilegesError reports whether networksetup output indicates the command
+// was denied for lack of admin privileges ("** Error: Command requires admin privileges.",
+// exit status 14). Matched on the message rather than the exit status, whose meaning
+// is undocumented.
+func isAdminPrivilegesError(out []byte) bool {
+	return strings.Contains(strings.ToLower(string(out)), "requires admin privileges")
 }
 
 // discoverNetworkServices returns a list of all network service names.

--- a/internal/sysproxy/system_darwin.go
+++ b/internal/sysproxy/system_darwin.go
@@ -162,11 +162,28 @@ func runElevated(cmds [][]string) ([]byte, error) {
 	for i, args := range cmds {
 		quoted := make([]string, len(args))
 		for j, a := range args {
-			quoted[j] = fmt.Sprintf("%q", a)
+			quoted[j] = shellQuote(a)
 		}
 		parts[i] = strings.Join(quoted, " ")
 	}
 	shellCmd := strings.Join(parts, "&&")
-	script := fmt.Sprintf(`do shell script %q with administrator privileges with prompt "Authorize Zen to modify system proxy settings"`, shellCmd)
+	script := fmt.Sprintf(`do shell script %s with administrator privileges with prompt "Authorize Zen to modify system proxy settings"`, appleScriptQuote(shellCmd))
 	return exec.Command("osascript", "-e", script).CombinedOutput()
+}
+
+// shellQuote wraps s in single quotes so that sh treats every character in it literally.
+// An embedded single quote is closed, escaped, and reopened. Network service names come from
+// networksetup and may contain anything, including $(...) and backticks, which would otherwise
+// be expanded by the shell inside "do shell script" - as root, on the elevated path.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+var appleScriptEscaper = strings.NewReplacer(`\`, `\\`, `"`, `\"`)
+
+// appleScriptQuote wraps s in double quotes for AppleScript, where only \ and " are special.
+// Go's %q is not a substitute: for non-printable runes it emits Go escapes (\u00XX, \a, \v)
+// that AppleScript does not understand, which would corrupt the command.
+func appleScriptQuote(s string) string {
+	return `"` + appleScriptEscaper.Replace(s) + `"`
 }

--- a/internal/sysproxy/system_darwin_test.go
+++ b/internal/sysproxy/system_darwin_test.go
@@ -1,0 +1,106 @@
+package sysproxy
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// hostileArgs contains values that a network service could plausibly be named and that the
+// shell, AppleScript, or both would interpret rather than pass through. The elevated path runs
+// as root, so an expansion here would be a privilege escalation.
+var hostileArgs = []string{
+	"Wi-Fi",
+	"$(id -un)",
+	"`id -un`",
+	"$HOME",
+	"${HOME}",
+	`quote"and\backslash`,
+	"it's an apostrophe",
+	"semicolon; echo pwned",
+	"pipe | echo pwned",
+	"and && echo pwned",
+	"newline\nsecond line",
+	"tab\there",
+	"Wi‑Fi Éthernet",
+}
+
+func TestShellQuote(t *testing.T) {
+	t.Parallel()
+
+	for _, arg := range hostileArgs {
+		t.Run(arg, func(t *testing.T) {
+			t.Parallel()
+
+			// printf writes its operand verbatim, so anything the shell expanded shows up as a diff.
+			out, err := exec.Command("sh", "-c", "/usr/bin/printf %s "+shellQuote(arg)).Output() // #nosec G204 -- feeding tainted input to the shell is the point of the test
+			if err != nil {
+				t.Fatalf("run sh: %v", err)
+			}
+
+			if string(out) != arg {
+				t.Fatalf("argument was altered by the shell: got %q, want %q", out, arg)
+			}
+		})
+	}
+}
+
+func TestAppleScriptQuote(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{`plain`, `"plain"`},
+		{`with "quotes"`, `"with \"quotes\""`},
+		{`with \backslash`, `"with \\backslash"`},
+		{`$(id -un)`, `"$(id -un)"`}, // AppleScript does not expand these; the shell layer must.
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			t.Parallel()
+
+			if got := appleScriptQuote(tt.in); got != tt.want {
+				t.Fatalf("appleScriptQuote(%q) = %s, want %s", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRunElevatedQuoting exercises the full quoting chain of runElevated - AppleScript string,
+// then shell word - without actually elevating, by running the same osascript "do shell script"
+// with a harmless command in place of networksetup.
+func TestRunElevatedQuoting(t *testing.T) {
+	t.Parallel()
+
+	if _, err := exec.LookPath("osascript"); err != nil {
+		t.Skipf("osascript unavailable: %v", err)
+	}
+
+	for _, arg := range hostileArgs {
+		t.Run(arg, func(t *testing.T) {
+			t.Parallel()
+
+			args := []string{"/usr/bin/printf", "[%s]", arg}
+			quoted := make([]string, len(args))
+			for i, a := range args {
+				quoted[i] = shellQuote(a)
+			}
+			script := fmt.Sprintf("do shell script %s", appleScriptQuote(strings.Join(quoted, " ")))
+
+			out, err := exec.Command("osascript", "-e", script).CombinedOutput()
+			if err != nil {
+				t.Fatalf("run osascript: %v (%q)", err, out)
+			}
+
+			// do shell script returns the output with newlines translated to carriage returns.
+			got := strings.ReplaceAll(strings.TrimSuffix(string(out), "\n"), "\r", "\n")
+			if want := "[" + arg + "]"; got != want {
+				t.Fatalf("argument was altered on the way to the command: got %q, want %q", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Self-explanatory.

### How did you verify your code works?

Manual testing:
1. Create a non-administrator account and log into it
2. Launch Zen and press "Start"
3. Verify that an `osascript` elevation dialog is being shown. No "Command requires admin privileges" error.

### What are the relevant issues?

Closes #761