### PR TITLE
fix: autostart path

### DIFF
--- a/internal/autostart/autostart_linux.go
+++ b/internal/autostart/autostart_linux.go
@@ -117,15 +117,17 @@ func (m Manager) Disable() (err error) {
 // getAutostartDir returns the autostart directory as defined in:
 // https://specifications.freedesktop.org/autostart-spec/autostart-spec-latest.html
 func getAutostartDir() (string, error) {
-	if configHome := os.Getenv("XDG_CONFIG_HOME"); configHome != "" {
-		return configHome, nil
-	}
+	configHome := os.Getenv("XDG_CONFIG_HOME")
 
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("get user home dir: %w", err)
+	if configHome == "" {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("get user home dir: %w", err)
+		}
+		configHome = filepath.Join(homeDir, ".config")
 	}
-	return filepath.Join(homeDir, ".config"), nil
+	
+	return filepath.Join(configHome, "autostart"), nil
 }
 
 // getDesktopPath returns the path of the .desktop file that autostarts the app.

--- a/internal/autostart/autostart_linux.go
+++ b/internal/autostart/autostart_linux.go
@@ -127,7 +127,7 @@ func getAutostartDir() (string, error) {
 		}
 		configHome = filepath.Join(homeDir, ".config")
 	}
-	
+
 	return filepath.Join(configHome, "autostart"), nil
 }
 

--- a/internal/autostart/autostart_linux.go
+++ b/internal/autostart/autostart_linux.go
@@ -19,6 +19,7 @@ Name={{.Name}}
 Comment=Automatically start {{.Name}} at user login
 Type=Application
 Exec={{.ExecPath}} --start --hidden
+Icon=zen-adblocker
 X-GNOME-Autostart-enabled=true`
 )
 


### PR DESCRIPTION
### What does this PR do?

<!--
**Please explain the purpose of your changes**, for example:

This PR addresses a privacy risk associated with writing logs to disk, where sensitive information about a client's traffic history could potentially be exposed to third parties - either located on the client's computer or during transmission for debugging purposes.

To mitigate this risk, the PR introduces a new logger.Redacted function, which enables us to easily redact sensitive data from production logs.
-->

Changes the path from `~/.config` to `~/.config/autostart` for autostart dir.

Also adds icon entry to make it easier to differentiate from other files if accessing via gui 

### How did you verify your code works?

<!--
**Please describe your testing strategy**:

- If you performed manual testing, list the steps to verify correct functionality, including edge cases if applicable.
- If new or existing automated tests cover the functionality, explicitly mention them.
-->

Its to the spec and the syntax seems correct 

### What are the relevant issues?

Closes #770
