### PR TITLE
internal/config: add v0.25.0 migration to move linux autostart entry

### DIFF
--- a/internal/config/migrations.go
+++ b/internal/config/migrations.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/irbis-sh/zen-desktop/internal/autostart"
+	"github.com/irbis-sh/zen-desktop/internal/constants"
 )
 
 type migration struct {
@@ -355,6 +357,47 @@ var migrations = []migration{
 			}
 			return nil
 		})
+	}},
+	{"v0.25.0", func(_ *Config) error {
+		if runtime.GOOS != "linux" {
+			return nil
+		}
+
+		// Before v0.25.0, the Linux autostart entry was written to $XDG_CONFIG_HOME
+		// (or ~/.config) rather than its autostart subdirectory. No desktop
+		// environment scans that location, so the entry never ran. The legacy file
+		// is useless wherever it is and always gets removed; its presence only
+		// tells us the user had autostart enabled, so the entry is recreated at
+		// the correct location.
+		configHome := os.Getenv("XDG_CONFIG_HOME")
+		if configHome == "" {
+			homeDir, err := os.UserHomeDir()
+			if err != nil {
+				return fmt.Errorf("get user home dir: %w", err)
+			}
+			configHome = filepath.Join(homeDir, ".config")
+		}
+		legacyPath := filepath.Join(configHome, constants.AppName+"-autostart.desktop")
+
+		if _, err := os.Stat(legacyPath); err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return fmt.Errorf("stat legacy autostart entry: %w", err)
+		}
+
+		var errs []error
+		if err := (autostart.Manager{}).Enable(); err != nil {
+			errs = append(errs, fmt.Errorf("enable autostart: %w", err))
+		}
+		if err := os.Remove(legacyPath); err != nil {
+			errs = append(errs, fmt.Errorf("remove legacy autostart entry: %w", err))
+		}
+		if len(errs) > 0 {
+			return errors.Join(errs...)
+		}
+		log.Printf("v0.25.0 migration: moved autostart entry to the autostart directory")
+		return nil
 	}},
 }
 

--- a/internal/config/migrations_test.go
+++ b/internal/config/migrations_test.go
@@ -1,6 +1,14 @@
 package config
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/irbis-sh/zen-desktop/internal/constants"
+)
 
 func TestMigrationV0220RemovesStaleAntiAdblockList(t *testing.T) {
 	prevConfigDir := ConfigDir
@@ -40,4 +48,119 @@ func TestMigrationV0220RemovesStaleAntiAdblockList(t *testing.T) {
 	if c.Filter.FilterLists[0].URL != keepURL {
 		t.Fatalf("unexpected list URL after migration: %s", c.Filter.FilterLists[0].URL)
 	}
+}
+
+func TestMigrationV0250MovesLinuxAutostartEntry(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("migration is a no-op outside linux")
+	}
+
+	m := findMigration(t, "v0.25.0")
+	desktopName := constants.AppName + "-autostart.desktop"
+
+	t.Run("moves legacy entry to autostart dir", func(t *testing.T) {
+		configHome := t.TempDir()
+		t.Setenv("XDG_CONFIG_HOME", configHome)
+
+		legacyPath := filepath.Join(configHome, desktopName)
+		if err := os.WriteFile(legacyPath, []byte("[Desktop Entry]"), 0644); err != nil {
+			t.Fatalf("write legacy entry: %v", err)
+		}
+
+		if err := m.fn(&Config{}); err != nil {
+			t.Fatalf("run migration: %v", err)
+		}
+
+		if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+			t.Errorf("legacy entry still present: %v", err)
+		}
+		newPath := filepath.Join(configHome, "autostart", desktopName)
+		data, err := os.ReadFile(newPath)
+		if err != nil {
+			t.Fatalf("read entry at new location: %v", err)
+		}
+		if !strings.Contains(string(data), "Exec=") {
+			t.Errorf("entry at new location lacks an Exec line: %q", data)
+		}
+	})
+
+	t.Run("keeps existing entry at new location", func(t *testing.T) {
+		configHome := t.TempDir()
+		t.Setenv("XDG_CONFIG_HOME", configHome)
+
+		legacyPath := filepath.Join(configHome, desktopName)
+		if err := os.WriteFile(legacyPath, []byte("[Desktop Entry]"), 0644); err != nil {
+			t.Fatalf("write legacy entry: %v", err)
+		}
+		newPath := filepath.Join(configHome, "autostart", desktopName)
+		if err := os.MkdirAll(filepath.Dir(newPath), 0755); err != nil {
+			t.Fatalf("create autostart dir: %v", err)
+		}
+		const existing = "[Desktop Entry]\nExec=/opt/zen --start --hidden"
+		if err := os.WriteFile(newPath, []byte(existing), 0644); err != nil {
+			t.Fatalf("write entry at new location: %v", err)
+		}
+
+		if err := m.fn(&Config{}); err != nil {
+			t.Fatalf("run migration: %v", err)
+		}
+
+		if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+			t.Errorf("legacy entry still present: %v", err)
+		}
+		data, err := os.ReadFile(newPath)
+		if err != nil {
+			t.Fatalf("read entry at new location: %v", err)
+		}
+		if string(data) != existing {
+			t.Errorf("entry at new location was modified: %q", data)
+		}
+	})
+
+	t.Run("removes legacy entry even if enable fails", func(t *testing.T) {
+		configHome := t.TempDir()
+		t.Setenv("XDG_CONFIG_HOME", configHome)
+
+		legacyPath := filepath.Join(configHome, desktopName)
+		if err := os.WriteFile(legacyPath, []byte("[Desktop Entry]"), 0644); err != nil {
+			t.Fatalf("write legacy entry: %v", err)
+		}
+		// A regular file at the autostart dir path makes Enable's MkdirAll fail.
+		if err := os.WriteFile(filepath.Join(configHome, "autostart"), nil, 0644); err != nil {
+			t.Fatalf("write autostart blocker file: %v", err)
+		}
+
+		if err := m.fn(&Config{}); err == nil {
+			t.Fatal("expected migration to return an error")
+		}
+
+		if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+			t.Errorf("legacy entry still present: %v", err)
+		}
+	})
+
+	t.Run("no-op without legacy entry", func(t *testing.T) {
+		configHome := t.TempDir()
+		t.Setenv("XDG_CONFIG_HOME", configHome)
+
+		if err := m.fn(&Config{}); err != nil {
+			t.Fatalf("run migration: %v", err)
+		}
+
+		newPath := filepath.Join(configHome, "autostart", desktopName)
+		if _, err := os.Stat(newPath); !os.IsNotExist(err) {
+			t.Errorf("entry unexpectedly created at new location: %v", err)
+		}
+	})
+}
+
+func findMigration(t *testing.T, version string) *migration {
+	t.Helper()
+	for i := range migrations {
+		if migrations[i].version == version {
+			return &migrations[i]
+		}
+	}
+	t.Fatalf("%s migration not found", version)
+	return nil
 }


### PR DESCRIPTION
### What does this PR do?

Creates a `v0.25.0` migration that fixes autostart for Linux users by recreating the `.desktop` file in a correct directory.

### How did you verify your code works?

Automated testing.

### What are the relevant issues?

This is a follow-up to #769 #770

<!--
**Please link any relevant issues**, for example:

Closes #123
-->
