### PR TITLE
Proxy HTTP client optimisation

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -26,6 +26,9 @@ const (
 	tlsHandshakeTimeout   = 20 * time.Second
 	responseHeaderTimeout = 3 * time.Minute
 	idleConnTimeout       = 90 * time.Second
+
+	maxIdleConns        = 512
+	maxIdleConnsPerHost = 16
 )
 
 // certGenerator is an interface capable of generating certificates for the proxy.
@@ -81,7 +84,8 @@ func NewProxy(filter filter, certGenerator certGenerator, port int, shouldProxy 
 		ForceAttemptHTTP2:     true,
 		TLSHandshakeTimeout:   tlsHandshakeTimeout,
 		ResponseHeaderTimeout: responseHeaderTimeout,
-		MaxIdleConns:          100,
+		MaxIdleConns:          maxIdleConns,
+		MaxIdleConnsPerHost:   maxIdleConnsPerHost,
 		IdleConnTimeout:       idleConnTimeout,
 	}
 	p.requestClient = &http.Client{

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -463,7 +463,7 @@ func (p *Proxy) addTransparentHost(host string) {
 // tunnel tunnels the connection between the client and the remote server
 // without inspecting the traffic.
 func (p *Proxy) tunnel(w net.Conn, r *http.Request) {
-	remoteConn, err := net.Dial("tcp", r.Host) // #nosec G704 -- this is a proxy; forwarding connections is its purpose
+	remoteConn, err := p.netDialer.DialContext(r.Context(), "tcp", r.Host) // #nosec G704 -- this is a proxy; forwarding connections is its purpose
 	if err != nil {
 		log.Printf("dialing remote(%s): %v", redacted.Redacted(r.Host), err)
 		w.Write([]byte("HTTP/1.1 502 Bad Gateway\r\n\r\n"))

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -20,6 +20,14 @@ import (
 	"github.com/irbis-sh/zen-desktop/internal/redacted"
 )
 
+const (
+	dialTimeout           = 60 * time.Second
+	dialKeepAlive         = 30 * time.Second
+	tlsHandshakeTimeout   = 20 * time.Second
+	responseHeaderTimeout = 3 * time.Minute
+	idleConnTimeout       = 90 * time.Second
+)
+
 // certGenerator is an interface capable of generating certificates for the proxy.
 type certGenerator interface {
 	GetCertificate(host string) (*tls.Certificate, error)
@@ -65,19 +73,21 @@ func NewProxy(filter filter, certGenerator certGenerator, port int, shouldProxy 
 	}
 
 	p.netDialer = &net.Dialer{
-		// Such high values are set to avoid timeouts on slow connections.
-		Timeout:   60 * time.Second,
-		KeepAlive: 30 * time.Second,
+		Timeout:   dialTimeout,
+		KeepAlive: dialKeepAlive,
 	}
 	p.requestTransport = &http.Transport{
-		DialContext:         p.netDialer.DialContext,
-		ForceAttemptHTTP2:   true,
-		TLSHandshakeTimeout: 20 * time.Second,
-		MaxIdleConns:        100,
-		IdleConnTimeout:     90 * time.Second,
+		DialContext:           p.netDialer.DialContext,
+		ForceAttemptHTTP2:     true,
+		TLSHandshakeTimeout:   tlsHandshakeTimeout,
+		ResponseHeaderTimeout: responseHeaderTimeout,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       idleConnTimeout,
 	}
 	p.requestClient = &http.Client{
-		Timeout:   60 * time.Second,
+		// Timeout is deliberately unset: it covers the response body read, which would make
+		// it exactly the total budget the timeouts above rule out. Ending a transfer is the
+		// client's call.
 		Transport: p.requestTransport,
 		// Let the client handle any redirects.
 		CheckRedirect: func(*http.Request, []*http.Request) error {
@@ -93,7 +103,9 @@ func NewProxy(filter filter, certGenerator certGenerator, port int, shouldProxy 
 // If Proxy was configured with a port of 0, the actual port will be returned.
 func (p *Proxy) Start() (int, error) {
 	p.server = &http.Server{
-		Handler:           p,
+		Handler: p,
+		// WriteTimeout is deliberately unset: it caps the whole handler, response write
+		// included, and would truncate large downloads and long-lived streams.
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 	listener, err := net.Listen("tcp", fmt.Sprintf("%s:%d", "127.0.0.1", p.port))

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -130,7 +130,15 @@ func (p *Proxy) Start() (int, error) {
 
 // Stop stops the proxy.
 func (p *Proxy) Stop() error {
-	if err := p.shutdownServer(); err != nil {
+	err := p.shutdownServer()
+
+	// Shutdown only closes inbound connections, and runs first so that requests still in
+	// flight cannot return an upstream connection to the pool after it has been drained.
+	// Left alone, those connections and their read and write goroutines outlive the proxy
+	// until idleConnTimeout.
+	p.requestClient.CloseIdleConnections()
+
+	if err != nil {
 		return fmt.Errorf("shut down server: %v", err)
 	}
 

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1,10 +1,12 @@
 package proxy
 
 import (
+	"bufio"
 	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -15,46 +17,24 @@ import (
 	"github.com/irbis-sh/zen-desktop/internal/process"
 )
 
-// TestRequestClientHasNoTotalTimeout is the direct guard for the bug this package
-// used to have: http.Client.Timeout covers the response body read, so setting it
-// caps how long a transfer may take and truncates large downloads and long-lived
-// streams mid-body. No behavioural test can stand in for this one, because any
-// value small enough to exercise in a test would also have to be reintroduced to
-// be observed.
-func TestRequestClientHasNoTotalTimeout(t *testing.T) {
+// TestNetDialerIsBounded pins the property every outbound path leans on: the shared
+// dialer must impose some connect timeout. Zero, or negative, hands the wait back to
+// the OS - over two minutes on Linux. The behavioural tests here supply a timeout of
+// their own, so none of them can catch it. What is pinned is the bound, not the value;
+// 60s stays open to retuning.
+func TestNetDialerIsBounded(t *testing.T) {
 	t.Parallel()
 
 	p := newTestProxy(t)
 
-	if p.requestClient.Timeout != 0 {
-		t.Fatalf("requestClient.Timeout = %v, want 0: a total timeout bounds the body read and truncates long transfers", p.requestClient.Timeout)
+	if p.netDialer.Timeout <= 0 {
+		t.Fatalf("netDialer.Timeout = %v, want > 0: an unbounded dial leaves the wait to the OS connect timeout", p.netDialer.Timeout)
 	}
 }
 
-// TestResponseHeaderTimeoutPreservesOldBudget pins the invariant that makes the
-// removal of the total timeout safe. The header wait replaced a 60s total timeout,
-// so as long as it stays at or above 60s, no request that used to succeed can begin
-// to fail: headers already had to arrive inside the old budget.
-func TestResponseHeaderTimeoutPreservesOldBudget(t *testing.T) {
-	t.Parallel()
-
-	p := newTestProxy(t)
-
-	transport, ok := p.requestTransport.(*http.Transport)
-	if !ok {
-		t.Fatalf("requestTransport is %T, want *http.Transport", p.requestTransport)
-	}
-
-	const previousTotalTimeout = 60 * time.Second
-	if transport.ResponseHeaderTimeout < previousTotalTimeout {
-		t.Fatalf("ResponseHeaderTimeout = %v, want >= %v so that requests which succeeded under the old total timeout still succeed", transport.ResponseHeaderTimeout, previousTotalTimeout)
-	}
-}
-
-// TestBodyOutlastsResponseHeaderTimeout proves the bound that replaced the total
-// timeout did not recreate it: a response body may take arbitrarily longer than the
-// header wait. Without this, the fix could be silently undone by moving the ceiling
-// from one field to another.
+// TestBodyOutlastsResponseHeaderTimeout holds the proxy to the only bound it may impose
+// on a response: the wait for headers. Once headers arrive the body may take as long as
+// it takes, which is what large downloads, SSE and long-lived streams all depend on.
 func TestBodyOutlastsResponseHeaderTimeout(t *testing.T) {
 	t.Parallel()
 
@@ -83,7 +63,10 @@ func TestBodyOutlastsResponseHeaderTimeout(t *testing.T) {
 	}))
 	defer target.Close()
 
-	client := startTestProxy(t, headerTimeout)
+	addr := startTestProxy(t, func(p *Proxy) {
+		transportOf(t, p).ResponseHeaderTimeout = headerTimeout
+	})
+	client := proxyClient(t, addr)
 
 	resp, err := client.Get(target.URL)
 	if err != nil {
@@ -101,9 +84,8 @@ func TestBodyOutlastsResponseHeaderTimeout(t *testing.T) {
 	}
 }
 
-// TestStallBeforeHeadersReturns502 proves the replacement bound actually fires.
-// Without it, TestBodyOutlastsResponseHeaderTimeout would also pass if the header
-// timeout were never applied at all.
+// TestStallBeforeHeadersReturns502 covers the bound itself: a server that accepts the
+// connection and then never answers must not hold the client open indefinitely.
 func TestStallBeforeHeadersReturns502(t *testing.T) {
 	t.Parallel()
 
@@ -118,7 +100,10 @@ func TestStallBeforeHeadersReturns502(t *testing.T) {
 	defer target.Close()
 	defer close(release)
 
-	client := startTestProxy(t, 100*time.Millisecond)
+	addr := startTestProxy(t, func(p *Proxy) {
+		transportOf(t, p).ResponseHeaderTimeout = 100 * time.Millisecond
+	})
+	client := proxyClient(t, addr)
 
 	resp, err := client.Get(target.URL)
 	if err != nil {
@@ -130,6 +115,75 @@ func TestStallBeforeHeadersReturns502(t *testing.T) {
 		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusBadGateway)
 	}
 }
+
+// TestTunnelDialHonoursDialerTimeout checks that the tunnel's dial is bounded by the
+// proxy's own dialer rather than by the OS connect timeout, which runs to over two
+// minutes on Linux and pins both this goroutine and the client's socket for the
+// duration. The target is reachable, so only a dial that consults the dialer can fail.
+func TestTunnelDialHonoursDialerTimeout(t *testing.T) {
+	t.Parallel()
+
+	target := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
+	defer target.Close()
+
+	// A deadline that has already elapsed by the time the dialer reaches its first
+	// address, so the failure needs no unroutable host and no waiting.
+	addr := startTestProxy(t, func(p *Proxy) {
+		p.netDialer.Timeout = 1 * time.Nanosecond
+	})
+
+	_, _, resp := connectThrough(t, addr, target.Listener.Addr().String())
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusBadGateway)
+	}
+}
+
+// TestTunnelForwardsTraffic covers the CONNECT path end to end, so that changes to how
+// the tunnel dials cannot quietly break the tunnel itself. No TLS is involved: httptest
+// listens on 127.0.0.1, and proxyConnect sends bare IPs down the tunnel rather than
+// MITM'ing them.
+func TestTunnelForwardsTraffic(t *testing.T) {
+	t.Parallel()
+
+	const want = "through the tunnel"
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		io.WriteString(w, want)
+	}))
+	defer target.Close()
+
+	addr := startTestProxy(t, nil)
+
+	conn, br, resp := connectThrough(t, addr, target.Listener.Addr().String())
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("CONNECT status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, target.URL, nil)
+	if err != nil {
+		t.Fatalf("build tunnelled request: %v", err)
+	}
+	if err := req.Write(conn); err != nil {
+		t.Fatalf("write tunnelled request: %v", err)
+	}
+
+	tunnelled, err := http.ReadResponse(br, req)
+	if err != nil {
+		t.Fatalf("read tunnelled response: %v", err)
+	}
+	defer tunnelled.Body.Close()
+
+	body, err := io.ReadAll(tunnelled.Body)
+	if err != nil {
+		t.Fatalf("read tunnelled body: %v", err)
+	}
+	if string(body) != want {
+		t.Fatalf("body = %q, want %q", body, want)
+	}
+}
+
+// backstopTimeout keeps a regression from hanging CI. It sits far above every delay
+// these tests exercise, so it never fires on a healthy path.
+const backstopTimeout = 10 * time.Second
 
 // newTestProxy builds a Proxy without starting it.
 func newTestProxy(t *testing.T) *Proxy {
@@ -143,21 +197,18 @@ func newTestProxy(t *testing.T) *Proxy {
 	return p
 }
 
-// startTestProxy starts a proxy with a shortened response header timeout and returns
-// a client routed through it.
-func startTestProxy(t *testing.T, headerTimeout time.Duration) *http.Client {
+// startTestProxy starts a proxy and returns its address. configure, if non-nil, may
+// shorten timeouts before the proxy begins serving; it has to run there, because the
+// transport and the dialer read their timeout fields without synchronisation and Start
+// is what hands the proxy to serving goroutines.
+func startTestProxy(t *testing.T, configure func(*Proxy)) string {
 	t.Helper()
 
 	p := newTestProxy(t)
 
-	// This must happen before Start. http.Transport reads its timeout fields without
-	// synchronisation, and Start is what hands the proxy to serving goroutines, so
-	// mutating the field afterwards is a data race.
-	transport, ok := p.requestTransport.(*http.Transport)
-	if !ok {
-		t.Fatalf("requestTransport is %T, want *http.Transport", p.requestTransport)
+	if configure != nil {
+		configure(p)
 	}
-	transport.ResponseHeaderTimeout = headerTimeout
 
 	port, err := p.Start()
 	if err != nil {
@@ -169,17 +220,72 @@ func startTestProxy(t *testing.T, headerTimeout time.Duration) *http.Client {
 		}
 	})
 
-	proxyURL, err := url.Parse(fmt.Sprintf("http://127.0.0.1:%d", port))
+	return fmt.Sprintf("127.0.0.1:%d", port)
+}
+
+// proxyClient returns a client that routes its requests through the proxy at addr.
+func proxyClient(t *testing.T, addr string) *http.Client {
+	t.Helper()
+
+	proxyURL, err := url.Parse("http://" + addr)
 	if err != nil {
 		t.Fatalf("parse proxy url: %v", err)
 	}
 
 	return &http.Client{
 		Transport: &http.Transport{Proxy: http.ProxyURL(proxyURL)},
-		// A backstop so a regression fails the test rather than hanging CI. It sits far
-		// above every delay used here and never fires on the paths being exercised.
-		Timeout: 10 * time.Second,
+		Timeout:   backstopTimeout,
 	}
+}
+
+// connectThrough asks the proxy at proxyAddr to tunnel to target and returns the reply
+// along with the connection and reader it arrived on, so a caller that got a 200 can
+// keep speaking down the tunnel. Read what follows from the returned reader, not from
+// the reply: a 200 to CONNECT carries no body, so everything after the status line has
+// already been buffered here.
+func connectThrough(t *testing.T, proxyAddr, target string) (net.Conn, *bufio.Reader, *http.Response) {
+	t.Helper()
+
+	conn, err := net.DialTimeout("tcp", proxyAddr, backstopTimeout)
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	t.Cleanup(func() { conn.Close() })
+	if err := conn.SetDeadline(time.Now().Add(backstopTimeout)); err != nil {
+		t.Fatalf("set deadline: %v", err)
+	}
+
+	req := &http.Request{
+		Method: http.MethodConnect,
+		// Opaque rather than Path: Request.Write only emits the authority form that
+		// CONNECT requires when the URL carries no path.
+		URL:    &url.URL{Opaque: target},
+		Host:   target,
+		Header: make(http.Header),
+	}
+	if err := req.Write(conn); err != nil {
+		t.Fatalf("write CONNECT: %v", err)
+	}
+
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, req)
+	if err != nil {
+		t.Fatalf("read CONNECT response: %v", err)
+	}
+
+	return conn, br, resp
+}
+
+// transportOf returns the proxy's outbound transport, which is held behind an interface.
+func transportOf(t *testing.T, p *Proxy) *http.Transport {
+	t.Helper()
+
+	transport, ok := p.requestTransport.(*http.Transport)
+	if !ok {
+		t.Fatalf("requestTransport is %T, want *http.Transport", p.requestTransport)
+	}
+
+	return transport
 }
 
 // noopFilter passes every request and response through untouched.

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -18,10 +18,11 @@ import (
 )
 
 // TestNetDialerIsBounded pins the property every outbound path leans on: the shared
-// dialer must impose some connect timeout. Zero, or negative, hands the wait back to
-// the OS - over two minutes on Linux. The behavioural tests here supply a timeout of
-// their own, so none of them can catch it. What is pinned is the bound, not the value;
-// 60s stays open to retuning.
+// dialer must impose a usable connect timeout. Zero is no timeout at all and hands the
+// wait back to the OS - over two minutes on Linux. Negative is degenerate the other
+// way: net.Dialer reads it as an already-expired deadline, so every dial fails at once.
+// The behavioural tests here supply a timeout of their own, so none of them can catch
+// either. What is pinned is the bound, not the value; 60s stays open to retuning.
 func TestNetDialerIsBounded(t *testing.T) {
 	t.Parallel()
 
@@ -111,28 +112,6 @@ func TestStallBeforeHeadersReturns502(t *testing.T) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusBadGateway {
-		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusBadGateway)
-	}
-}
-
-// TestTunnelDialHonoursDialerTimeout checks that the tunnel's dial is bounded by the
-// proxy's own dialer rather than by the OS connect timeout, which runs to over two
-// minutes on Linux and pins both this goroutine and the client's socket for the
-// duration. The target is reachable, so only a dial that consults the dialer can fail.
-func TestTunnelDialHonoursDialerTimeout(t *testing.T) {
-	t.Parallel()
-
-	target := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
-	defer target.Close()
-
-	// A deadline that has already elapsed by the time the dialer reaches its first
-	// address, so the failure needs no unroutable host and no waiting.
-	addr := startTestProxy(t, func(p *Proxy) {
-		p.netDialer.Timeout = 1 * time.Nanosecond
-	})
-
-	_, _, resp := connectThrough(t, addr, target.Listener.Addr().String())
 	if resp.StatusCode != http.StatusBadGateway {
 		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusBadGateway)
 	}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1,0 +1,203 @@
+package proxy
+
+import (
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/irbis-sh/zen-desktop/internal/process"
+)
+
+// TestRequestClientHasNoTotalTimeout is the direct guard for the bug this package
+// used to have: http.Client.Timeout covers the response body read, so setting it
+// caps how long a transfer may take and truncates large downloads and long-lived
+// streams mid-body. No behavioural test can stand in for this one, because any
+// value small enough to exercise in a test would also have to be reintroduced to
+// be observed.
+func TestRequestClientHasNoTotalTimeout(t *testing.T) {
+	t.Parallel()
+
+	p := newTestProxy(t)
+
+	if p.requestClient.Timeout != 0 {
+		t.Fatalf("requestClient.Timeout = %v, want 0: a total timeout bounds the body read and truncates long transfers", p.requestClient.Timeout)
+	}
+}
+
+// TestResponseHeaderTimeoutPreservesOldBudget pins the invariant that makes the
+// removal of the total timeout safe. The header wait replaced a 60s total timeout,
+// so as long as it stays at or above 60s, no request that used to succeed can begin
+// to fail: headers already had to arrive inside the old budget.
+func TestResponseHeaderTimeoutPreservesOldBudget(t *testing.T) {
+	t.Parallel()
+
+	p := newTestProxy(t)
+
+	transport, ok := p.requestTransport.(*http.Transport)
+	if !ok {
+		t.Fatalf("requestTransport is %T, want *http.Transport", p.requestTransport)
+	}
+
+	const previousTotalTimeout = 60 * time.Second
+	if transport.ResponseHeaderTimeout < previousTotalTimeout {
+		t.Fatalf("ResponseHeaderTimeout = %v, want >= %v so that requests which succeeded under the old total timeout still succeed", transport.ResponseHeaderTimeout, previousTotalTimeout)
+	}
+}
+
+// TestBodyOutlastsResponseHeaderTimeout proves the bound that replaced the total
+// timeout did not recreate it: a response body may take arbitrarily longer than the
+// header wait. Without this, the fix could be silently undone by moving the ceiling
+// from one field to another.
+func TestBodyOutlastsResponseHeaderTimeout(t *testing.T) {
+	t.Parallel()
+
+	const (
+		headerTimeout = 250 * time.Millisecond
+		// Kept a multiple of headerTimeout rather than equal to it, so that retuning either
+		// constant cannot land a write on top of the header deadline.
+		chunkDelay = 2 * headerTimeout
+		chunks     = 4
+	)
+
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		rc := http.NewResponseController(w)
+		// Flush the headers before the first sleep. The deadline being exercised runs only
+		// until headers arrive, so without this the first body write would also be the
+		// first header byte and the test would measure the wrong thing.
+		w.WriteHeader(http.StatusOK)
+		rc.Flush()
+
+		// Total body time is chunks*chunkDelay, well past headerTimeout.
+		for range chunks {
+			time.Sleep(chunkDelay)
+			io.WriteString(w, "x")
+			rc.Flush()
+		}
+	}))
+	defer target.Close()
+
+	client := startTestProxy(t, headerTimeout)
+
+	resp, err := client.Get(target.URL)
+	if err != nil {
+		t.Fatalf("get through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+
+	if want := strings.Repeat("x", chunks); string(body) != want {
+		t.Fatalf("body = %q, want %q", body, want)
+	}
+}
+
+// TestStallBeforeHeadersReturns502 proves the replacement bound actually fires.
+// Without it, TestBodyOutlastsResponseHeaderTimeout would also pass if the header
+// timeout were never applied at all.
+func TestStallBeforeHeadersReturns502(t *testing.T) {
+	t.Parallel()
+
+	release := make(chan struct{})
+	target := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		<-release
+	}))
+	// Defer order is load-bearing. httptest.Server.Close waits for in-flight
+	// handlers, and this handler only returns once released - the proxy hanging up
+	// upstream does not wake it. Defers run last-in-first-out, so releasing must be
+	// deferred after Close to run before it.
+	defer target.Close()
+	defer close(release)
+
+	client := startTestProxy(t, 100*time.Millisecond)
+
+	resp, err := client.Get(target.URL)
+	if err != nil {
+		t.Fatalf("get through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusBadGateway)
+	}
+}
+
+// newTestProxy builds a Proxy without starting it.
+func newTestProxy(t *testing.T) *Proxy {
+	t.Helper()
+
+	p, err := NewProxy(noopFilter{}, unusedCertGenerator{}, 0, nil)
+	if err != nil {
+		t.Fatalf("create proxy: %v", err)
+	}
+
+	return p
+}
+
+// startTestProxy starts a proxy with a shortened response header timeout and returns
+// a client routed through it.
+func startTestProxy(t *testing.T, headerTimeout time.Duration) *http.Client {
+	t.Helper()
+
+	p := newTestProxy(t)
+
+	// This must happen before Start. http.Transport reads its timeout fields without
+	// synchronisation, and Start is what hands the proxy to serving goroutines, so
+	// mutating the field afterwards is a data race.
+	transport, ok := p.requestTransport.(*http.Transport)
+	if !ok {
+		t.Fatalf("requestTransport is %T, want *http.Transport", p.requestTransport)
+	}
+	transport.ResponseHeaderTimeout = headerTimeout
+
+	port, err := p.Start()
+	if err != nil {
+		t.Fatalf("start proxy: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := p.Stop(); err != nil {
+			t.Errorf("stop proxy: %v", err)
+		}
+	})
+
+	proxyURL, err := url.Parse(fmt.Sprintf("http://127.0.0.1:%d", port))
+	if err != nil {
+		t.Fatalf("parse proxy url: %v", err)
+	}
+
+	return &http.Client{
+		Transport: &http.Transport{Proxy: http.ProxyURL(proxyURL)},
+		// A backstop so a regression fails the test rather than hanging CI. It sits far
+		// above every delay used here and never fires on the paths being exercised.
+		Timeout: 10 * time.Second,
+	}
+}
+
+// noopFilter passes every request and response through untouched.
+type noopFilter struct{}
+
+func (noopFilter) HandleRequest(*http.Request, process.Info) (*http.Response, error) {
+	return nil, nil
+}
+
+func (noopFilter) HandleResponse(*http.Request, *http.Response, process.Info) error {
+	return nil
+}
+
+// unusedCertGenerator satisfies NewProxy's non-nil check. Certificates are only
+// generated for MITM'd CONNECT requests, so it is never called on the plain-HTTP
+// path these tests exercise.
+type unusedCertGenerator struct{}
+
+func (unusedCertGenerator) GetCertificate(string) (*tls.Certificate, error) {
+	return nil, errors.New("not implemented")
+}


### PR DESCRIPTION
### What does this PR do?

Implements a few optimisations to the HTTP client that proxies requests:
- Drops the total request timeout, replacing it with stage-specific timeouts. Long-lived connections (SSE/long-poll) can now survive instead of having to reopen periodically.
- Pass the request context to CONNECT's `net.Dial`. Minor improvement: by the point of dialing, the connection is already hijacked, so client's cancellation won't cancel the dial. However, this makes the dial timeout consistent (60 seconds) instead of letting the OS terminate the connection.
- Increase both per-host and total idle connection limits to better handle all-machine traffic.
- Close outbound connections on proxy shutdown.

### How did you verify your code works?

New automated tests; manual testing.

### What are the relevant issues?

<!--
**Please link any relevant issues**, for example:

Closes #123
-->
