### PR TITLE
all: make update restart reopen the window and restore proxy state

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -38,14 +38,18 @@ function App() {
           action: {
             text: t('app.update.restart'),
             onClick: () => {
-              try {
-                RestartApplication();
-              } catch (error) {
+              const restartingToast = AppToaster.show({
+                message: t('app.update.restarting'),
+                intent: 'primary',
+                timeout: 0,
+              });
+              RestartApplication().catch((error) => {
+                AppToaster.dismiss(restartingToast);
                 AppToaster.show({
                   message: t('app.update.restartFailed', { error }),
                   intent: 'danger',
                 });
-              }
+              });
             },
           },
         });

--- a/frontend/src/i18n/locales/de-DE.json
+++ b/frontend/src/i18n/locales/de-DE.json
@@ -13,6 +13,7 @@
     "update": {
       "restart": "Neustarten",
       "restartFailed": "App kann nicht neu gestartet werden: {{error}}",
+      "restarting": "Wird neu gestartet...",
       "updateAvailable": "Eine neue Version von Zen ist verfügbar."
     }
   },

--- a/frontend/src/i18n/locales/en-US.json
+++ b/frontend/src/i18n/locales/en-US.json
@@ -13,6 +13,7 @@
     "update": {
       "restart": "Restart",
       "restartFailed": "Failed to restart app: {{error}}",
+      "restarting": "Restarting...",
       "updateAvailable": "A new version of Zen is available."
     }
   },

--- a/frontend/src/i18n/locales/fr-FR.json
+++ b/frontend/src/i18n/locales/fr-FR.json
@@ -13,6 +13,7 @@
     "update": {
       "restart": "Redémarrer",
       "restartFailed": "Échec du redémarrage",
+      "restarting": "Redémarrage...",
       "updateAvailable": "Mise à jour disponible"
     }
   },

--- a/frontend/src/i18n/locales/it-IT.json
+++ b/frontend/src/i18n/locales/it-IT.json
@@ -13,6 +13,7 @@
     "update": {
       "restart": "Riavvia",
       "restartFailed": "Impossibile riavviare l'app: {{error}}",
+      "restarting": "Riavvio in corso...",
       "updateAvailable": "È disponibile una nuova versione di Zen."
     }
   },

--- a/frontend/src/i18n/locales/ja-JP.json
+++ b/frontend/src/i18n/locales/ja-JP.json
@@ -13,6 +13,7 @@
     "update": {
       "restart": "再起動",
       "restartFailed": "アプリの再起動に失敗しました: {{error}}",
+      "restarting": "再起動しています...",
       "updateAvailable": "Zen の新しいバージョンが利用可能です。"
     }
   },

--- a/frontend/src/i18n/locales/kk-KZ.json
+++ b/frontend/src/i18n/locales/kk-KZ.json
@@ -11,8 +11,9 @@
       "settings": "Баптаулар"
     },
     "update": {
-      "restart": "Қайта бастау",
-      "restartFailed": "Қосымшаны қайта бастау сәтсіз аяқталды: {{error}}",
+      "restart": "Қайта жүктеу",
+      "restartFailed": "Қосымшаны қайта жүктеу сәтсіз аяқталды: {{error}}",
+      "restarting": "Қайта жүктелуде...",
       "updateAvailable": "Zen-нің жаңа нұсқасы бар."
     }
   },

--- a/frontend/src/i18n/locales/ru-RU.json
+++ b/frontend/src/i18n/locales/ru-RU.json
@@ -13,6 +13,7 @@
     "update": {
       "restart": "Перезапустить",
       "restartFailed": "Не удалось перезапустить приложение: {{error}}",
+      "restarting": "Перезапуск...",
       "updateAvailable": "Доступна новая версия Zen."
     }
   },

--- a/frontend/src/i18n/locales/tr-TR.json
+++ b/frontend/src/i18n/locales/tr-TR.json
@@ -13,6 +13,7 @@
     "update": {
       "restart": "Yeniden başlat",
       "restartFailed": "Uygulama yeniden başlatılamadı: {{error}}",
+      "restarting": "Yeniden başlatılıyor...",
       "updateAvailable": "Zen'in yeni bir sürümü mevcut."
     }
   },

--- a/frontend/src/i18n/locales/vi-VN.json
+++ b/frontend/src/i18n/locales/vi-VN.json
@@ -13,6 +13,7 @@
     "update": {
       "restart": "Khởi động lại",
       "restartFailed": "Không thể khởi động lại ứng dụng: {{error}}",
+      "restarting": "Đang khởi động lại...",
       "updateAvailable": "Đã có phiên bản Zen mới."
     }
   },

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -13,6 +13,7 @@
     "update": {
       "restart": "重启",
       "restartFailed": "重新启动应用失败: {{error}}",
+      "restarting": "正在重启...",
       "updateAvailable": "Zen 有新版本可用。"
     }
   },

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -13,6 +13,7 @@
     "update": {
       "restart": "重新啟動",
       "restartFailed": "重新啟動應用程式失敗：{{error}}",
+      "restarting": "正在重新啟動...",
       "updateAvailable": "Zen 有新版本可用。"
     }
   },

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -62,6 +62,10 @@ type App struct {
 	systrayMgr      *systray.Manager
 	filterListStore *filterliststore.FilterListStore
 	whitelistSrv    *whitelistserver.Server
+	restartMu       sync.Mutex
+	// pendingRestart records an armed restart.
+	pendingRestart      bool
+	pendingRestartStart bool
 }
 
 // NewApp initializes the app.
@@ -137,6 +141,8 @@ func (a *App) commonStartup(ctx context.Context) {
 	close(a.startupDone)
 }
 
+// BeforeClose runs when the user asks to quit. Returning true prevents the
+// window from closing.
 func (a *App) BeforeClose(ctx context.Context) bool {
 	log.Println("shutting down")
 	if err := a.StopProxy(); err != nil {
@@ -151,7 +157,15 @@ func (a *App) BeforeClose(ctx context.Context) bool {
 		if err != nil {
 			return false
 		}
-		return dialog != "Yes"
+		if dialog != "Yes" {
+			// The quit was cancelled; don't leave a relaunch armed for a
+			// later normal quit.
+			a.restartMu.Lock()
+			a.pendingRestart = false
+			a.restartMu.Unlock()
+			return true
+		}
+		return false
 	}
 	a.systrayMgr.Quit()
 	return false
@@ -487,11 +501,46 @@ func parseLaunchArgs(args []string) (start, hidden bool) {
 	return start, hidden
 }
 
+// RestartApplication schedules a relaunch of the application and quits.
+// The replacement process is spawned by [App.RunPendingRestart] only after the
+// Wails runtime has shut down: spawning it here would race the
+// single-instance lock, which this process holds until it exits, making the
+// new process hand its arguments to this dying one and exit instead of
+// starting up. A failure to spawn the replacement is logged, not surfaced
+// to the caller.
 func (a *App) RestartApplication() error {
-	cmd := exec.Command(os.Args[0], os.Args[1:]...) // #nosec G204 G702 -- restarting the app with the same arguments is ok
-	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("restart application: %w", err)
-	}
+	a.proxyMu.Lock()
+	proxyOn := a.proxyOn
+	a.proxyMu.Unlock()
+
+	a.restartMu.Lock()
+	a.pendingRestart, a.pendingRestartStart = true, proxyOn
+	a.restartMu.Unlock()
+
 	runtime.Quit(a.ctx)
 	return nil
+}
+
+// RunPendingRestart spawns the replacement process recorded by
+// [App.RestartApplication], if any. It must only be called after wails.Run has
+// returned, when this process is about to release the single-instance lock.
+func (a *App) RunPendingRestart() {
+	a.restartMu.Lock()
+	pending, start := a.pendingRestart, a.pendingRestartStart
+	a.restartMu.Unlock()
+	if !pending {
+		return
+	}
+
+	// --hidden is deliberately not carried over: a restart is user-initiated,
+	// so the window must be visible. Any flag added in future is dropped on
+	// restart unless it is handled here.
+	var args []string
+	if start {
+		args = []string{"--start"}
+	}
+	cmd := exec.Command(os.Args[0], args...) // #nosec G204 G702 -- re-executing our own binary with a fixed argv is ok
+	if err := cmd.Start(); err != nil {
+		log.Printf("failed to restart application: %v", err)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -98,4 +98,6 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	app.RunPendingRestart()
 }


### PR DESCRIPTION
### What does this PR do?

Fixes the issue where the "Restart" button relaunched the app with its original `argv`s, launching it with `--hidden` if it's been autostarted, or with the proxy turned off if the app has been launched manually even it's been on before the restart. The relaunch now just passes `--start` if the proxy was running before the restart.

Also, fixes the (supposedly rare, personally never had it happen) issue where the single-instance lock is still held during a restart and the new instance gets terminated.

Also fixes Kazakh translation for the term "restart".

### How did you verify your code works?

Manual testing.

### What are the relevant issues?

<!--
**Please link any relevant issues**, for example:

Closes #123
-->
